### PR TITLE
Updateupgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 dist: focal
 sudo: required
 mono: none
-dotnet: 8.0
+dotnet: 9.0
 services: docker
 before_install: 
  - chmod +x ./scripts/*.sh

--- a/src/Domain.LinnApps/Domain.LinnApps.csproj
+++ b/src/Domain.LinnApps/Domain.LinnApps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Domain.LinnApps</AssemblyName>
 		<RootNamespace>Linn.Stores2.Domain.LinnApps</RootNamespace>
 	</PropertyGroup>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Domain</AssemblyName>
 		<RootNamespace>Linn.Stores2.Domain</RootNamespace>
 	</PropertyGroup>

--- a/src/Facade/Facade.csproj
+++ b/src/Facade/Facade.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Facade</AssemblyName>
 		<RootNamespace>Linn.Stores2.Facade</RootNamespace>
 	</PropertyGroup>

--- a/src/IoC/IoC.csproj
+++ b/src/IoC/IoC.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.IoC</AssemblyName>
 		<RootNamespace>Linn.Stores2.IoC</RootNamespace>
 	</PropertyGroup>

--- a/src/IoC/MessagingExtensions.cs
+++ b/src/IoC/MessagingExtensions.cs
@@ -13,8 +13,9 @@
             // all the routing keys the Listener cares about need to be registered here:
             var routingKeys = new[] { ThingMessage.RoutingKey };
 
-            return services.AddSingleton<ChannelConfiguration>(d => new ChannelConfiguration("stores2", routingKeys))
-                .AddSingleton(d => new EventingBasicConsumer(d.GetService<ChannelConfiguration>()?.ConsumerChannel));
+            return services
+                .AddSingleton<ChannelConfiguration>(d => new ChannelConfiguration("stores2", routingKeys))
+                .AddSingleton(d => new AsyncEventingBasicConsumer(d.GetService<ChannelConfiguration>()?.ConsumerChannel));
         }
 
         public static IServiceCollection AddMessageHandlers(this IServiceCollection services)

--- a/src/Messaging.Host/Dockerfile
+++ b/src/Messaging.Host/Dockerfile
@@ -1,7 +1,6 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:8.0
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
-COPY bin/release/net8.0/publish/ /app/bin/
+COPY bin/release/net9.0/publish/ /app/bin/
 ENV TZ=Europe/London
 
 CMD dotnet /app/bin/Linn.Finance.Messaging.Host.dll

--- a/src/Messaging.Host/Messaging.Host.csproj
+++ b/src/Messaging.Host/Messaging.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Messaging.Host</AssemblyName>
 		<RootNamespace>Linn.Stores2.Messaging.Host</RootNamespace>
 		<Nullable>enable</Nullable>
@@ -12,8 +12,8 @@
 		<PackageReference Include="Linn.Common.Configuration" Version="2.0.0" />
 		<PackageReference Include="Linn.Common.Logging" Version="2.0.0" />
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Messaging.Host/Messaging.Host.csproj
+++ b/src/Messaging.Host/Messaging.Host.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Linn.Common.Logging" Version="2.0.0" />
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Messaging/Messaging.csproj
+++ b/src/Messaging/Messaging.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Messaging</AssemblyName>
 		<RootNamespace>Linn.Stores2.Messaging</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Linn.Common.Messaging.RabbitMQ" Version="3.2.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Messaging/Messaging.csproj
+++ b/src/Messaging/Messaging.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Linn.Common.Messaging.RabbitMQ" Version="3.2.4" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Persistence.LinnApps/Persistence.LinnApps.csproj
+++ b/src/Persistence.LinnApps/Persistence.LinnApps.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
-		<PackageReference Include="Oracle.EntityFrameworkCore" Version="7.21.13" />
+		<PackageReference Include="Oracle.EntityFrameworkCore" Version="9.23.60" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Persistence.LinnApps/Persistence.LinnApps.csproj
+++ b/src/Persistence.LinnApps/Persistence.LinnApps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<RootNamespace>Linn.Stores2.Persistence.LinnApps</RootNamespace>
 		<AssemblyName>Linn.Stores2.Persistence.LinnApps</AssemblyName>
 	</PropertyGroup>
@@ -12,7 +12,7 @@
 		<PackageReference Include="Linn.Common.Persistence" Version="5.0.1" />
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 		<PackageReference Include="Oracle.EntityFrameworkCore" Version="7.21.13" />
 	</ItemGroup>
 

--- a/src/Persistence/Persistence.csproj
+++ b/src/Persistence/Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Persistence</AssemblyName>
 		<RootNamespace>Linn.Stores2.Persistence</RootNamespace>
 	</PropertyGroup>

--- a/src/Proxy/Proxy.csproj
+++ b/src/Proxy/Proxy.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Linn.Common.Configuration" Version="2.0.0" />
 		<PackageReference Include="Linn.Common.Proxy" Version="3.0.1" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
-		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.160" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Proxy/Proxy.csproj
+++ b/src/Proxy/Proxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Proxy</AssemblyName>
 		<RootNamespace>Linn.Stores2.Proxy</RootNamespace>
 	</PropertyGroup>
@@ -10,7 +10,7 @@
 		<PackageReference Include="Linn.Common.Configuration" Version="2.0.0" />
 		<PackageReference Include="Linn.Common.Proxy" Version="3.0.1" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
-		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.160" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Resources/Resources.csproj
+++ b/src/Resources/Resources.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Resources</AssemblyName>
 		<RootNamespace>Linn.Stores2.Resources</RootNamespace>
 	</PropertyGroup>

--- a/src/Scheduling.Host/Dockerfile
+++ b/src/Scheduling.Host/Dockerfile
@@ -1,8 +1,7 @@
-FROM mcr.microsoft.com/dotnet/runtime:8.0
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 ENV TZ=Europe/London
 
-COPY /bin/release/net8.0/publish/ /app/bin/
+COPY /bin/release/net9.0/publish/ /app/bin/
 
 CMD dotnet /app/bin/Linn.Stores2.Scheduling.Host.dll

--- a/src/Scheduling.Host/Scheduling.Host.csproj
+++ b/src/Scheduling.Host/Scheduling.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Scheduling.Host-319D7819-8043-45B8-A3FE-7B31A1ADEDF5</UserSecretsId>
@@ -10,7 +10,7 @@
   <ItemGroup>
 	  <PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 	  <PackageReference Include="Linn.Common.Scheduling" Version="3.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/Service.Host/Dockerfile
+++ b/src/Service.Host/Dockerfile
@@ -1,5 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:8.0
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 ARG gitBranch=unspecified
 ENV TZ=Europe/London
@@ -9,7 +8,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5050
 
-COPY bin/release/net8.0/publish/ /app/bin/
+COPY bin/release/net9.0/publish/ /app/bin/
 COPY client/build/ /app/client/build/
 COPY views/ /app/views/
      

--- a/src/Service.Host/Service.Host.csproj
+++ b/src/Service.Host/Service.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Service.Host</AssemblyName>
 		<RootNamespace>Linn.Stores2.Service.Host</RootNamespace>
 		<PreserveCompilationContext>true</PreserveCompilationContext>

--- a/src/Service.Host/package-lock.json
+++ b/src/Service.Host/package-lock.json
@@ -29,7 +29,7 @@
         "notistack": "^3.0.2",
         "npm": "^11.2.0",
         "oidc-client": "^1.11.5",
-        "oidc-client-ts": "^3.1.0",
+        "oidc-client-ts": "^3.2.0",
         "process": "^0.11.10",
         "prop-types": "^15.8.1",
         "query-string": "^9.1.1",
@@ -14393,9 +14393,9 @@
       }
     },
     "node_modules/oidc-client-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.1.0.tgz",
-      "integrity": "sha512-IDopEXjiwjkmJLYZo6BTlvwOtnlSniWZkKZoXforC/oLZHC9wkIxd25Kwtmo5yKFMMVcsp3JY6bhcNJqdYk8+g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.2.0.tgz",
+      "integrity": "sha512-wUvVcG3SXzZDKHxi/VGQGaTUk9qguMKfYh26Y1zOVrQsu1zp85JWx/SjZzKSXK5j3NA1RcasgMoaHe6gt1WNtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^4.0.0"

--- a/src/Service.Host/package.json
+++ b/src/Service.Host/package.json
@@ -75,7 +75,7 @@
     "notistack": "^3.0.2",
     "npm": "^11.2.0",
     "oidc-client": "^1.11.5",
-    "oidc-client-ts": "^3.1.0",
+    "oidc-client-ts": "^3.2.0",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
     "query-string": "^9.1.1",

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Service</AssemblyName>
 		<RootNamespace>Linn.Stores2.Service</RootNamespace>
 	</PropertyGroup>

--- a/tests/Integration/Integration.Tests/Integration.Tests.csproj
+++ b/tests/Integration/Integration.Tests/Integration.Tests.csproj
@@ -2,22 +2,22 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Integration.Tests</AssemblyName>
 		<RootNamespace>Linn.Stores2.Integration.Tests</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.2" />
+		<PackageReference Include="FluentAssertions" Version="8.1.1" />
 		<PackageReference Include="Linn.Common.Persistence" Version="5.0.1" />
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 		<PackageReference Include="Linn.Common.Reporting.Resources" Version="1.7.2" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="nunit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/TestData/TestData/TestData.csproj
+++ b/tests/TestData/TestData/TestData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <AssemblyName>Linn.Stores2.TestData</AssemblyName>
 	  <RootNamespace>Linn.Stores2.TestData</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Unit/Domain.LinnApps.Tests/Domain.LinnApps.Tests.csproj
+++ b/tests/Unit/Domain.LinnApps.Tests/Domain.LinnApps.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Stores2.Domain.LinnApps.Tests</AssemblyName>
     <RootNamespace>Linn.Stores2.Domain.LinnApps.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="FluentAssertions" Version="8.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/Unit/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Unit/Domain.Tests/Domain.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Stores2.Domain.Tests</AssemblyName>
     <RootNamespace>Linn.Stores2.Domain.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="8.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/Unit/Facade.Tests/Facade.Tests.csproj
+++ b/tests/Unit/Facade.Tests/Facade.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Facade.Tests</AssemblyName>
 		<RootNamespace>Linn.Stores2.Facade.Tests</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.2" />
+		<PackageReference Include="FluentAssertions" Version="8.1.1" />
 		<PackageReference Include="Linn.Common.Facade" Version="12.0.0" />
 		<PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="6.0.0" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/Unit/Messaging.Tests/Messaging.Tests.csproj
+++ b/tests/Unit/Messaging.Tests/Messaging.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Messaging.Tests</AssemblyName>
 		<RootNamespace>Linn.Stores2.Messaging.Tests</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.2" />
+		<PackageReference Include="FluentAssertions" Version="8.1.1" />
 		<PackageReference Include="Linn.Common.Messaging.RabbitMQ" Version="3.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/Unit/Proxy.Tests/Proxy.Tests.csproj
+++ b/tests/Unit/Proxy.Tests/Proxy.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Stores2.Proxy.Tests</AssemblyName>
 		<RootNamespace>Linn.Stores2.Proxy.Tests</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.2" />
+		<PackageReference Include="FluentAssertions" Version="8.1.1" />
 		<PackageReference Include="Linn.Common.Proxy.LinnApps" Version="3.2.0" />
 		<PackageReference Include="Linn.Common.Serialization.Json" Version="3.1.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />


### PR DESCRIPTION
 - mostly nuget stuff + dotnet 9, so install that on your machine if you dont have it already
 - only things i didnt upgrade were
   - ManagedDataAccess - obvious reasons, but I did update Oracle.EntityFrameworkCore and it seems to work
   - RabbitMQ Client - looks like break changes + we are not using it in this solution yet anyways (will need to update the stuff in common too probably to make it work anyway)