### PR TITLE
way of checking credit note and document line

### DIFF
--- a/src/Domain.LinnApps/External/IDocumentProxy.cs
+++ b/src/Domain.LinnApps/External/IDocumentProxy.cs
@@ -1,0 +1,9 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.External
+{
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+
+    public interface IDocumentProxy
+    {
+        DocumentResult  GetCreditNote(int documentNumber, int? documentLine);
+    }
+}

--- a/src/Domain.LinnApps/Requisitions/DocumentResult.cs
+++ b/src/Domain.LinnApps/Requisitions/DocumentResult.cs
@@ -1,7 +1,7 @@
-﻿using Linn.Stores2.Domain.LinnApps.Parts;
-
-namespace Linn.Stores2.Domain.LinnApps.Requisitions
+﻿namespace Linn.Stores2.Domain.LinnApps.Requisitions
 {
+    using Linn.Stores2.Domain.LinnApps.Parts;
+
     public class DocumentResult
     {
         public DocumentResult(string name, int number, int? line, decimal? qty, string partNumber)

--- a/src/Domain.LinnApps/Requisitions/DocumentResult.cs
+++ b/src/Domain.LinnApps/Requisitions/DocumentResult.cs
@@ -1,0 +1,28 @@
+﻿using Linn.Stores2.Domain.LinnApps.Parts;
+
+namespace Linn.Stores2.Domain.LinnApps.Requisitions
+{
+    public class DocumentResult
+    {
+        public DocumentResult(string name, int number, int? line, decimal? qty, string partNumber)
+        {
+            this.DocumentName = name;
+            this.DocumentNumber = number;
+            this.LineNumber = line;
+            this.Quantity = qty;
+            this.PartNumber = partNumber;
+        }
+
+        public string DocumentName { get; protected set; }
+
+        public int DocumentNumber { get; protected set; }
+
+        public int? LineNumber { get; protected set; }
+
+        public decimal? Quantity { get; protected set; }
+
+        public string PartNumber { get; protected set; }
+
+        public Part Part { get; set; }
+    }
+}

--- a/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
@@ -65,5 +65,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             string toState = null,
             string batchRef = null,
             DateTime? batchDate = null);
+
+        DocumentResult GetDocument(string docName, int docNumber, int? lineNumber);
     }
 }

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -3,6 +3,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Security.Cryptography;
     using System.Threading.Tasks;
 
     using Linn.Common.Authorisation;
@@ -47,6 +48,8 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
 
         private readonly IRepository<Nominal, string> nominalRepository;
 
+        private readonly IDocumentProxy documentProxy;
+
         public RequisitionManager(
             IAuthorisationService authService,
             IRepository<RequisitionHeader, int> repository,
@@ -62,7 +65,8 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             IRepository<StockPool, string> stockPoolRepository,
             IRepository<StoresFunction, string> storesFunctionRepository,
             IRepository<Department, string> departmentRepository,
-            IRepository<Nominal, string> nominalRepository)
+            IRepository<Nominal, string> nominalRepository,
+            IDocumentProxy documentProxy)
         {
             this.authService = authService;
             this.repository = repository;
@@ -79,6 +83,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             this.storesFunctionRepository = storesFunctionRepository;
             this.departmentRepository = departmentRepository;
             this.nominalRepository = nominalRepository;
+            this.documentProxy = documentProxy;
         }
         
         public async Task<RequisitionHeader> CancelHeader(
@@ -556,7 +561,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                     firstLine.Document1Type));
             }
 
-            if (req.Part == null && req.Lines.Count == 0 && function.PartNumberRequired())
+            if (req.Part == null && req.Lines.Count == 0 && function.PartNumberRequired() && (function.PartSource != "C"))
             {
                 throw new RequisitionException("Lines are required if header does not specify part");
             }
@@ -602,6 +607,16 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             }
 
             return req;
+        }
+
+        public DocumentResult GetDocument(string docName, int docNumber, int? lineNumber)
+        {
+            if (docName == "C")
+            {
+                return this.documentProxy.GetCreditNote(docNumber, lineNumber);
+            }
+
+            return null;
         }
 
         private static void DoProcessResultCheck(ProcessResult result)

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -3,7 +3,6 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Security.Cryptography;
     using System.Threading.Tasks;
 
     using Linn.Common.Authorisation;

--- a/src/IoC/ServiceExtensions.cs
+++ b/src/IoC/ServiceExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Linn.Common.Proxy;
-
-namespace Linn.Stores2.IoC
+﻿namespace Linn.Stores2.IoC
 {
     using System.Net.Http;
 
@@ -8,6 +6,7 @@ namespace Linn.Stores2.IoC
     using Linn.Common.Configuration;
     using Linn.Common.Facade;
     using Linn.Common.Pdf;
+    using Linn.Common.Proxy;
     using Linn.Common.Proxy.LinnApps;
     using Linn.Common.Rendering;
     using Linn.Common.Reporting.Models;

--- a/src/IoC/ServiceExtensions.cs
+++ b/src/IoC/ServiceExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Linn.Stores2.IoC
+﻿using Linn.Common.Proxy;
+
+namespace Linn.Stores2.IoC
 {
     using System.Net.Http;
 
@@ -23,6 +25,7 @@
     using Linn.Stores2.Facade.ResourceBuilders;
     using Linn.Stores2.Facade.Services;
     using Linn.Stores2.Proxy;
+    using Linn.Stores2.Proxy.External;
     using Linn.Stores2.Resources;
     using Linn.Stores2.Resources.Parts;
     using Linn.Stores2.Resources.Requisitions;
@@ -53,6 +56,8 @@
                 .AddScoped<IStoragePlaceAuditPack, StoragePlaceAuditPack>()
                 .AddTransient<IDatabaseSequenceService, DatabaseSequenceService>()
                 .AddTransient<IDatabaseService, DatabaseService>()
+                .AddTransient<IRestClient, RestClient>()
+                .AddScoped<IDocumentProxy, DocumentProxy>()
                 .AddTransient<IStockService, StockService>()
                 .AddTransient<IStoresService, StoresService>()
                 .AddScoped<IGoodsInLogReportService, GoodsInLogReportService>()

--- a/src/Proxy/External/DocumentProxy.cs
+++ b/src/Proxy/External/DocumentProxy.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Linn.Common.Configuration;
+using Linn.Common.Proxy;
+using Linn.Common.Serialization.Json;
+using Linn.Stores2.Domain.LinnApps.External;
+using Linn.Stores2.Domain.LinnApps.Requisitions;
+using Linn.Stores2.Resources.External;
+
+namespace Linn.Stores2.Proxy.External
+{
+    public class DocumentProxy : IDocumentProxy
+    {
+        private readonly IRestClient restClient;
+
+        public DocumentProxy(IRestClient restClient)
+        {
+            this.restClient = restClient;
+        }
+
+        public DocumentResult GetCreditNote(int documentNumber, int? documentLine)
+        {
+            DocumentResult result = null;
+
+            var uri = $"{ConfigurationManager.Configuration["PROXY_ROOT"]}/sales/credit-notes/{documentNumber}";
+
+            var response = this.restClient.Get(CancellationToken.None, new Uri(uri, UriKind.RelativeOrAbsolute), new Dictionary<string, string>(), this.JsonHeaders()).Result;
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var json = new JsonSerializer();
+                var creditNote = json.Deserialize<CreditNoteResource>(response.Value);
+                if (documentLine == null)
+                {
+                    result = new DocumentResult("C", documentNumber, null, null, null);
+                }
+                else
+                {
+                    var line = creditNote.Details.SingleOrDefault(l => l.LineNumber == documentLine.Value);
+                    if (line != null)
+                    {
+                        result = new DocumentResult("C", documentNumber, documentLine, line.Quantity, line.ArticleNumber);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private IDictionary<string, string[]> JsonHeaders()
+        {
+            return new Dictionary<string, string[]> { { "Accept", new[] { "application/json" } } };
+        }
+    }
+}

--- a/src/Proxy/External/DocumentProxy.cs
+++ b/src/Proxy/External/DocumentProxy.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Reflection.PortableExecutable;
-using System.Threading;
-using System.Threading.Tasks;
-using Linn.Common.Configuration;
-using Linn.Common.Proxy;
-using Linn.Common.Serialization.Json;
-using Linn.Stores2.Domain.LinnApps.External;
-using Linn.Stores2.Domain.LinnApps.Requisitions;
-using Linn.Stores2.Resources.External;
-
-namespace Linn.Stores2.Proxy.External
+﻿namespace Linn.Stores2.Proxy.External
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using Linn.Common.Configuration;
+    using Linn.Common.Proxy;
+    using Linn.Common.Serialization.Json;
+    using Linn.Stores2.Domain.LinnApps.External;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Resources.External;
+
     public class DocumentProxy : IDocumentProxy
     {
         private readonly IRestClient restClient;

--- a/src/Resources/External/CreditNoteDetailResource.cs
+++ b/src/Resources/External/CreditNoteDetailResource.cs
@@ -1,0 +1,17 @@
+﻿namespace Linn.Stores2.Resources.External
+{
+    public class CreditNoteDetailResource
+    {
+        public int DocumentNumber { get; set; }
+
+        public string DocumentType { get; set; }
+
+        public int LineNumber { get; set; }
+
+        public string LineType { get; set; }
+
+        public string ArticleNumber { get; set; }
+
+        public decimal Quantity { get; set; }
+    }
+}

--- a/src/Resources/External/CreditNoteResource.cs
+++ b/src/Resources/External/CreditNoteResource.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Linn.Stores2.Resources.External
+{
+    public class CreditNoteResource
+    {
+        public string DocumentType { get; set; }
+
+        public int DocumentNumber { get; set; }
+
+        public string DocumentDate { get; set; }
+
+        public int AccountId { get; set; }
+
+        public IEnumerable<CreditNoteDetailResource> Details { get; set; }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/ContextBase.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Linn.Common.Authorisation;
+using Linn.Common.Persistence;
+using Linn.Stores2.Domain.LinnApps.Accounts;
+using Linn.Stores2.Domain.LinnApps.Parts;
+using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+using Linn.Stores2.Domain.LinnApps.Stock;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    public class ContextBase : ContextBaseForStrategies
+    {
+        protected CustRetCreationStrategy Sut { get; set; }
+
+        protected IRepository<Employee, int> EmployeeRepository { get; set; }
+
+        protected IRepository<Part, string> PartRepository { get; set; }
+
+        protected IRepository<StorageLocation, int> StorageLocationRepository { get; set; }
+
+        protected IAuthorisationService AuthorisationService { get; set; }
+
+        [SetUp]
+        public void SetUpContext()
+        {
+            this.EmployeeRepository = Substitute.For<IRepository<Employee, int>>();
+            this.PartRepository = Substitute.For<IRepository<Part, string>>();
+            this.StorageLocationRepository = Substitute.For<IRepository<StorageLocation, int>>();
+            this.AuthorisationService = Substitute.For<IAuthorisationService>();
+            this.Sut = new CustRetCreationStrategy(
+                this.AuthorisationService,
+                this.EmployeeRepository,
+                this.PartRepository,
+                this.StorageLocationRepository,
+                this.RequisitionRepository,
+                this.RequisitionManager
+                );
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/ContextBase.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Linn.Common.Authorisation;
-using Linn.Common.Persistence;
-using Linn.Stores2.Domain.LinnApps.Accounts;
-using Linn.Stores2.Domain.LinnApps.Parts;
-using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
-using Linn.Stores2.Domain.LinnApps.Stock;
-using NSubstitute;
-using NUnit.Framework;
-
-namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
 {
+    using Linn.Common.Authorisation;
+    using Linn.Common.Persistence;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using NSubstitute;
+    using NUnit.Framework;
+
     public class ContextBase : ContextBaseForStrategies
     {
         protected CustRetCreationStrategy Sut { get; set; }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentAndLineDoesntMatch.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentAndLineDoesntMatch.cs
@@ -1,0 +1,47 @@
+﻿using Linn.Stores2.Domain.LinnApps.Exceptions;
+using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+using Linn.Stores2.Domain.LinnApps.Requisitions;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using FluentAssertions;
+
+namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    public class WhenCreatingAndDocumentAndLineDoesntMatch : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.RequisitionCreationContext = new RequisitionCreationContext
+            {
+                Function = new StoresFunction("CUSTRET"),
+                Document1Type = "C",
+                Document1Number = 100,
+                Document1Line = 1
+            };
+
+            this.AuthorisationService.HasPermissionFor(
+                    AuthorisedActions.GetRequisitionActionByFunction(this.RequisitionCreationContext.Function.FunctionCode),
+                    Arg.Any<IEnumerable<string>>())
+                .Returns(true);
+
+            this.RequisitionManager.GetDocument(this.RequisitionCreationContext.Document1Type,
+                    100,
+                    1)
+                .Returns((DocumentResult)null);
+
+            this.action = async () => await this.Sut.Create(this.RequisitionCreationContext);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<CreateRequisitionException>();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentAndLineDoesntMatch.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentAndLineDoesntMatch.cs
@@ -1,15 +1,15 @@
-﻿using Linn.Stores2.Domain.LinnApps.Exceptions;
-using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
-using Linn.Stores2.Domain.LinnApps.Requisitions;
-using NSubstitute;
-using NUnit.Framework;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using System;
-using FluentAssertions;
-
-namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using NSubstitute;
+    using NUnit.Framework;
+
     public class WhenCreatingAndDocumentAndLineDoesntMatch : ContextBase
     {
         private Func<Task> action;

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentDoesntExist.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentDoesntExist.cs
@@ -1,0 +1,46 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    public class WhenCreatingAndDocumentDoesntExist : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.RequisitionCreationContext = new RequisitionCreationContext
+            {
+                Function = new StoresFunction("CUSTRET"),
+                Document1Type = "C",
+                Document1Number = 100
+            };
+
+            this.AuthorisationService.HasPermissionFor(
+                    AuthorisedActions.GetRequisitionActionByFunction(this.RequisitionCreationContext.Function.FunctionCode),
+                    Arg.Any<IEnumerable<string>>())
+                .Returns(true);
+
+            this.RequisitionManager.GetDocument(this.RequisitionCreationContext.Document1Type,
+                    100,
+                    null)
+                .Returns((DocumentResult) null);
+
+            this.action = async () => await this.Sut.Create(this.RequisitionCreationContext);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<CreateRequisitionException>();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentDoesntExist.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndDocumentDoesntExist.cs
@@ -5,8 +5,8 @@
     using System.Threading.Tasks;
     using FluentAssertions;
     using Linn.Stores2.Domain.LinnApps.Exceptions;
-    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using NSubstitute;
     using NUnit.Framework;
 

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndNoDocument1Supplied.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndNoDocument1Supplied.cs
@@ -1,14 +1,14 @@
 ﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
 {
-    using Linn.Stores2.Domain.LinnApps.Exceptions;
-    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
-    using Linn.Stores2.Domain.LinnApps.Requisitions;
-    using NSubstitute;
-    using NUnit.Framework;
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System;
     using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using NSubstitute;
+    using NUnit.Framework;
 
     public class WhenCreatingAndNoDocument1Supplied : ContextBase
     {

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndNoDocument1Supplied.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndNoDocument1Supplied.cs
@@ -1,0 +1,39 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System;
+    using FluentAssertions;
+
+    public class WhenCreatingAndNoDocument1Supplied : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.RequisitionCreationContext = new RequisitionCreationContext
+            {
+                Function = new StoresFunction("CUSTRET")
+            };
+
+            this.AuthorisationService.HasPermissionFor(
+                    AuthorisedActions.GetRequisitionActionByFunction(this.RequisitionCreationContext.Function.FunctionCode),
+                    Arg.Any<IEnumerable<string>>())
+                .Returns(true);
+
+            this.action = async () => await this.Sut.Create(this.RequisitionCreationContext);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<CreateRequisitionException>();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndUnauthorised.cs
@@ -4,8 +4,8 @@
     using System.Threading.Tasks;
     using FluentAssertions;
     using Linn.Stores2.Domain.LinnApps.Exceptions;
-    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using NUnit.Framework;
 
     public class WhenCreatingAndUnauthorised : ContextBase

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndUnauthorised.cs
@@ -1,0 +1,33 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using NUnit.Framework;
+
+    public class WhenCreatingAndUnauthorised : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.RequisitionCreationContext = new RequisitionCreationContext
+            {
+                Function = new StoresFunction("CUSTRET"),
+                Document1Type = "C",
+                Document1Number = 100
+            };
+            this.action = async () => await this.Sut.Create(this.RequisitionCreationContext);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<UnauthorisedActionException>();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndWrongFunctionCode.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndWrongFunctionCode.cs
@@ -4,8 +4,8 @@
     using System.Threading.Tasks;
     using FluentAssertions;
     using Linn.Stores2.Domain.LinnApps.Exceptions;
-    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
     using NUnit.Framework;
 
     public class WhenCreatingAndWrongFunctionCode : ContextBase

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndWrongFunctionCode.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/CustRetCreationStrategyTests/WhenCreatingAndWrongFunctionCode.cs
@@ -1,0 +1,33 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionCreationStrategyTests.CustRetCreationStrategyTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using NUnit.Framework;
+
+    public class WhenCreatingAndWrongFunctionCode : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.RequisitionCreationContext = new RequisitionCreationContext
+            {
+                Function = new StoresFunction("SOMETHING ELSE"),
+                Document1Type = "C",
+                Document1Number = 100
+            };
+            this.action = async () => await this.Sut.Create(this.RequisitionCreationContext);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<CreateRequisitionException>();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
@@ -49,6 +49,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
 
         protected IStoresService StoresService { get; private set; }
 
+        protected IDocumentProxy DocumentProxy { get; private set; }
+
 
         [SetUp]
         public void SetUpContext()
@@ -68,6 +70,7 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
             this.StateRepository = Substitute.For<IRepository<StockState, string>>();
             this.StockPoolRepository = Substitute.For<IRepository<StockPool, string>>();
             this.PalletRepository = Substitute.For<IRepository<StoresPallet, int>>();
+            this.DocumentProxy = Substitute.For<IDocumentProxy>();
 
             this.StoresService.ValidStockPool(Arg.Any<Part>(), Arg.Any<StockPool>())
                 .Returns(new ProcessResult(true, "Stock Pool Ok"));
@@ -93,7 +96,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
                 this.StockPoolRepository,
                 this.StoresFunctionRepository,
                 this.DepartmentRepository,
-                this.NominalRepository);
+                this.NominalRepository,
+                this.DocumentProxy);
         }
     }
 }


### PR DESCRIPTION
Working my way through VALID_CREDIT_NOTE from REQ_UT
Expanded RequisitionManager to include checking of document
Added checking credit number is real and if there is a line then checking that exists as well
Could extend document proxy to look up other document types like purchase order 