### PR TITLE
lack of reverse_trans causing reqs to half book

### DIFF
--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -128,7 +128,8 @@
             DateTime? batchDate = null,
             string category = null,
             int? document2Number = null,
-            string document2Type = null)
+            string document2Type = null,
+            string reverseTrans = "N")
         {
             this.ReqSource = "STORES2";
             this.CreatedBy = createdBy;
@@ -161,6 +162,7 @@
             this.Document2 = document2Number;
             this.Document2Name = Document2Name;
 
+            this.IsReverseTransaction = reverseTrans;
             this.IsReversed = "N";
 
             this.Lines = new List<RequisitionLine>();


### PR DESCRIPTION
when doing LDREQs finding the reqs didn't book properly without reverse_trans set to 'N' instead of null