### PR TITLE
allow multiple lines on req creation on SuReq

### DIFF
--- a/src/Domain.LinnApps/Requisitions/CreationStrategies/SuReqCreationStrategy.cs
+++ b/src/Domain.LinnApps/Requisitions/CreationStrategies/SuReqCreationStrategy.cs
@@ -106,10 +106,14 @@
 
             await this.repository.AddAsync(req);
 
+
             // lines
             try
             {
-                await this.requisitionManager.AddRequisitionLine(req, context.FirstLineCandidate);
+                foreach (var line in context.Lines)
+                {
+                    await this.requisitionManager.AddRequisitionLine(req, line);
+                }
             }
             catch (DomainException ex)
             {

--- a/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
@@ -65,8 +65,10 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             string toState = null,
             string batchRef = null,
             DateTime? batchDate = null,
-            int? document1Line = null);
+            int? document1Line = null,
+            IEnumerable<LineCandidate> lines = null);
 
+        Task<RequisitionLine> ValidateLineCandidate(LineCandidate candidate);
 
         Task<DocumentResult> GetDocument(string docName, int docNumber, int? lineNumber);
 

--- a/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
@@ -54,7 +54,7 @@
             this.Cancelled = "N";
             
             this.Document1Number = document1Number ?? reqNumber;
-            this.Document1Line = document1Line;
+            this.Document1Line = string.IsNullOrEmpty(document1Name) ? lineNumber: document1Line;
             this.Document1Type = string.IsNullOrEmpty(document1Name) ? "REQ" : document1Name;
         }
         

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -560,7 +560,8 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             string toState = null,
             string batchRef = null,
             DateTime? batchDate = null,
-            int? document1Line = null)
+            int? document1Line = null,
+            IEnumerable<LineCandidate> lines = null)
         {
             // just try and construct a req with a single line
             // exceptions will be thrown if any of the validation fails
@@ -619,29 +620,17 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             {
                 throw new CreateRequisitionException($"Lines are required for {functionCode}");
             }
-            
-            if (firstLine != null)
+
+            if (lines != null)
             {
-                var firstLinePart = !string.IsNullOrEmpty(firstLine?.PartNumber)
-                                        ? await this.partRepository.FindByIdAsync(firstLine.PartNumber)
-                                        : null;
-                var transactionDefinition = !string.IsNullOrEmpty(firstLine?.TransactionDefinition)
-                                                ? await this.transactionDefinitionRepository.FindByIdAsync(firstLine.TransactionDefinition) : null;
-
-                if (firstLine.Moves != null && firstLine.Moves.Any())
+                foreach (var candidate in lines)
                 {
-                    await this.CheckMoves(firstLine.PartNumber, firstLine.Moves.ToList());
+                    req.AddLine(await this.ValidateLineCandidate(candidate));
                 }
-
-                req.AddLine(new RequisitionLine(
-                    0,
-                    1,
-                    firstLinePart,
-                    firstLine.Qty,
-                    transactionDefinition,
-                    firstLine.Document1,
-                    firstLine.Document1Line.GetValueOrDefault(),
-                    firstLine.Document1Type));
+            }
+            else if (firstLine != null)
+            {
+                req.AddLine(await this.ValidateLineCandidate(firstLine));
             }
 
             // move below to its own function?
@@ -736,6 +725,33 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             }
 
             return req;
+        }
+
+        public async Task<RequisitionLine> ValidateLineCandidate(LineCandidate candidate)
+        {
+            var part = !string.IsNullOrEmpty(candidate?.PartNumber)
+                ? await this.partRepository.FindByIdAsync(candidate.PartNumber)
+                : null;
+
+            var transactionDefinition = !string.IsNullOrEmpty(candidate?.TransactionDefinition)
+                ? await this.transactionDefinitionRepository.FindByIdAsync(candidate.TransactionDefinition) : null;
+
+            if (candidate.Moves != null && candidate.Moves.Any())
+            {
+                await this.CheckMoves(candidate.PartNumber, candidate.Moves.ToList());
+            }
+
+            var line = new RequisitionLine(
+                0,
+                candidate.LineNumber,
+                part,
+                candidate.Qty,
+                transactionDefinition,
+                candidate.Document1,
+                candidate.Document1Line.GetValueOrDefault(),
+                candidate.Document1Type);
+
+            return line;
         }
 
         public async Task<DocumentResult> GetDocument(string docName, int docNumber, int? lineNumber)

--- a/src/Facade/Services/RequisitionFacadeService.cs
+++ b/src/Facade/Services/RequisitionFacadeService.cs
@@ -160,7 +160,9 @@
                     resource.FromState,
                     resource.ToState,
                     resource.BatchRef,
-                    string.IsNullOrEmpty(resource.BatchDate) ? null : DateTime.Parse(resource.BatchDate));
+                    string.IsNullOrEmpty(resource.BatchDate) ? null : DateTime.Parse(resource.BatchDate),
+                    resource.Document1Line,
+                    resource.Lines.Select(BuildLineCandidateFromResource));
 
                 return new SuccessResult<RequisitionHeaderResource>(resource);
             }

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -240,7 +240,7 @@ function Requisition({ creating }) {
 
     const canAddLines = () => {
         // can only add one line when creating
-        if (creating && formState.lines?.length) {
+        if (creating && formState.lines?.length && formState.storesFunction?.code != 'SUREQ') {
             return false;
         }
 

--- a/tests/Integration/Integration.Tests/RequisitionModuleTests/WhenValidating.cs
+++ b/tests/Integration/Integration.Tests/RequisitionModuleTests/WhenValidating.cs
@@ -5,9 +5,6 @@
     using System.Net.Http.Json;
 
     using FluentAssertions;
-
-    using Linn.Stores2.Domain.LinnApps;
-    using Linn.Stores2.Domain.LinnApps.Accounts;
     using Linn.Stores2.Domain.LinnApps.Exceptions;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
     using Linn.Stores2.Resources.Accounts;
@@ -74,7 +71,8 @@
                 null,
                 null,
                 null,
-                null).Throws(new CancelRequisitionException("error"));
+                null,
+                lines: Arg.Any<IEnumerable<LineCandidate>>()).Throws(new CancelRequisitionException("error"));
             this.Response = this.Client.PostAsJsonAsync("/requisitions/validate", this.resource).Result;
         }
 

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLineCandidateAndNoQty.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLineCandidateAndNoQty.cs
@@ -1,0 +1,30 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using NUnit.Framework;
+
+    public class WhenValidatingLineCandidateAndNoQty : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.action = () => this.Sut.ValidateLineCandidate(
+                new LineCandidate
+                {
+                    Moves = new[] { new MoveSpecification { Qty = 0 } }
+                });
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<RequisitionException>().WithMessage("Move qty is invalid");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValilidatingAndSecondLineHasNoQty.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValilidatingAndSecondLineHasNoQty.cs
@@ -1,0 +1,77 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using Linn.Stores2.TestData.Parts;
+    using Linn.Stores2.TestData.Transactions;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    public class WhenValilidatingAndSecondLineHasNoQty : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.DepartmentRepository.FindByIdAsync("1607")
+                .Returns(new Department("1607", "DESC"));
+            this.NominalRepository.FindByIdAsync("2963")
+                .Returns(new Nominal("2963", "DESC"));
+            this.EmployeeRepository.FindByIdAsync(33087).Returns(new Employee());
+            this.StoresFunctionRepository.FindByIdAsync(TestFunctionCodes.LinnDeptReq.FunctionCode)
+                .Returns(TestFunctionCodes.LinnDeptReq);
+            this.StorageLocationRepository.FindByAsync(Arg.Any<Expression<Func<StorageLocation, bool>>>())
+                .Returns(new StorageLocation
+                { LocationId = 1, LocationCode = "E-USA-SNACKS" });
+            this.PartRepository.FindByIdAsync(TestParts.Cap003.PartNumber).Returns(TestParts.Cap003);
+            this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StockToSupplier.TransactionCode)
+                .Returns(TestTransDefs.StockToSupplier);
+
+            var lines = new List<LineCandidate>
+            {
+                new LineCandidate
+                {
+                    Moves = new[] { new MoveSpecification
+                    {
+                        Qty = 1, 
+                        ToLocation = "E-USA-SNACKS", 
+                        ToLocationId = 1
+                    } },
+                    PartNumber = TestParts.Cap003.PartNumber,
+                    TransactionDefinition = TestTransDefs.StockToSupplier.TransactionCode
+                },
+                new LineCandidate
+                {
+                    Moves = new[] { new MoveSpecification { Qty = 0 } }
+                }
+            };
+
+            this.action = () => this.Sut.Validate(
+                33087,
+                TestFunctionCodes.LinnDeptReq.FunctionCode,
+                "F",
+                null,
+                null,
+                "1607",
+                "2963",
+                lines.First(),
+                lines: lines);
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should().ThrowAsync<RequisitionException>().WithMessage("Requisition line requires a qty");
+        }
+    }
+}


### PR DESCRIPTION
have tested failure on SUREQ using automatic pick of CAP 004 which will always fails and seems to cancel remaining lines and not leave stock allocated