### PR TITLE
SUKIT

### DIFF
--- a/src/Domain.LinnApps/External/PurchaseOrderDetailResult.cs
+++ b/src/Domain.LinnApps/External/PurchaseOrderDetailResult.cs
@@ -1,0 +1,11 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.External
+{
+    public class PurchaseOrderDetailResult
+    {
+        public int Line { get; set; }
+
+        public string PartNumber { get; set; }
+
+        public decimal OurQty { get; set; }
+    }
+}

--- a/src/Domain.LinnApps/External/PurchaseOrderResult.cs
+++ b/src/Domain.LinnApps/External/PurchaseOrderResult.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace Linn.Stores2.Domain.LinnApps.External
+﻿namespace Linn.Stores2.Domain.LinnApps.External
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     public class PurchaseOrderResult
     {
         public int OrderNumber { get; set; }

--- a/src/Domain.LinnApps/External/PurchaseOrderResult.cs
+++ b/src/Domain.LinnApps/External/PurchaseOrderResult.cs
@@ -1,4 +1,7 @@
-﻿namespace Linn.Stores2.Domain.LinnApps.External
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Linn.Stores2.Domain.LinnApps.External
 {
     public class PurchaseOrderResult
     {
@@ -9,5 +12,13 @@
         public bool IsAuthorised { get; set; }
         
         public string DocumentType { get; set; }
+
+        public IEnumerable<PurchaseOrderDetailResult> Details { get; set; }
+
+        public decimal? OrderQty(int? lineNumber = null)
+        {
+            var detail = this.Details.SingleOrDefault(d => d.Line == (lineNumber ?? 1));
+            return detail?.OurQty;
+        }
     }
 }

--- a/src/Domain.LinnApps/Requisitions/CreationStrategies/AutomaticBookFromHeaderStrategy.cs
+++ b/src/Domain.LinnApps/Requisitions/CreationStrategies/AutomaticBookFromHeaderStrategy.cs
@@ -1,4 +1,7 @@
-﻿namespace Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies
+﻿using System;
+using Org.BouncyCastle.Ocsp;
+
+namespace Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies
 {
     using System.Linq;
     using System.Threading.Tasks;
@@ -131,6 +134,12 @@
                 {
                     req.NewPart = newPart;
                 }
+            }
+
+            if (context.Function.FunctionCode == "SUKIT")
+            {
+                req.FromCategory = "FREE";
+                req.ToCategory = "FREE";
             }
 
             await this.repository.AddAsync(req);

--- a/src/Domain.LinnApps/Requisitions/CreationStrategies/AutomaticBookFromHeaderStrategy.cs
+++ b/src/Domain.LinnApps/Requisitions/CreationStrategies/AutomaticBookFromHeaderStrategy.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Org.BouncyCastle.Ocsp;
-
-namespace Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies
+﻿namespace Linn.Stores2.Domain.LinnApps.Requisitions.CreationStrategies
 {
     using System.Linq;
     using System.Threading.Tasks;

--- a/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
@@ -1,10 +1,9 @@
-using Linn.Stores2.Domain.LinnApps.External;
-
 namespace Linn.Stores2.Domain.LinnApps.Requisitions
 {
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Linn.Stores2.Domain.LinnApps.External;
 
     public interface IRequisitionManager
     {

--- a/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
@@ -1,3 +1,5 @@
+using Linn.Stores2.Domain.LinnApps.External;
+
 namespace Linn.Stores2.Domain.LinnApps.Requisitions
 {
     using System;
@@ -83,5 +85,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             int? builtById,
             int? toLocationId,
             int? toPalletNumber);
+
+        Task CheckPurchaseOrderForOverAndFullyKitted(RequisitionHeader header, PurchaseOrderResult purchaseOrder);
     }
 }

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -90,7 +90,7 @@
 
         public string FromCategory { get; set; }
 
-        public string ToCategory { get; protected set; }
+        public string ToCategory { get; set; }
 
         public DateTime? BatchDate { get; set; }
 

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -404,18 +404,29 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
 
         public async Task CreateLinesAndBookAutoRequisitionHeader(RequisitionHeader header)
         {
-            DoProcessResultCheck(  
-                await this.requisitionStoredProcedures.CreateRequisitionLines(header.ReqNumber, null));
+            try
+            {
+                DoProcessResultCheck(
+                    await this.requisitionStoredProcedures.CreateRequisitionLines(header.ReqNumber, null));
 
-            DoProcessResultCheck(await this.requisitionStoredProcedures.CanBookRequisition(
-                                     header.ReqNumber,
-                                     null,
-                                     header.Quantity.GetValueOrDefault()));
+                DoProcessResultCheck(await this.requisitionStoredProcedures.CanBookRequisition(
+                    header.ReqNumber,
+                    null,
+                    header.Quantity.GetValueOrDefault()));
 
-            DoProcessResultCheck(await this.requisitionStoredProcedures.DoRequisition(
-                                     header.ReqNumber,
-                                     null,
-                                     header.CreatedBy.Id));
+                DoProcessResultCheck(await this.requisitionStoredProcedures.DoRequisition(
+                    header.ReqNumber,
+                    null,
+                    header.CreatedBy.Id));
+            }
+            catch (Exception e)
+            {
+                // cancel the req so it doesn't hang around unbooked and mess up validation
+                header.Cancel(e.Message, header.CreatedBy);
+                await this.transactionManager.CommitAsync();
+
+                throw;
+            }
         }
 
         public async Task<RequisitionHeader> CreateLoanReq(int loanNumber)
@@ -658,11 +669,18 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                 }
 
                 var orderRef = $"{po.DocumentType.Substring(0, 1)}{po.OrderNumber}";
-                if (batchRef != orderRef)
+                if (function.BatchRequired == "Y" && batchRef != orderRef)
                 {
                     throw new CreateRequisitionException(   
                             "You are trying to pass stock for payment from a different PO");
-                }   
+                }
+                
+                // SUKIT validation to replace STORES_OO.CAN_BE_KITTED
+                if (function.FunctionCode == "SUKIT")
+                {
+                    await this.CheckPurchaseOrderForOverAndFullyKitted(req, po);
+                }
+
             } 
             else if (function.PartSource == "WO")
             {
@@ -865,6 +883,34 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             await this.potentialMoveRepository.AddAsync(potentialMove);
 
             return new List<PotentialMoveDetail> { potentialMove }.AsEnumerable();
+        }
+
+        public async Task CheckPurchaseOrderForOverAndFullyKitted(RequisitionHeader header, PurchaseOrderResult purchaseOrder)
+        {
+            if (header.Document1Name == "PO" && purchaseOrder != null && purchaseOrder.OrderQty(header.Document1Line).HasValue)
+            {
+                var reqs = await this.repository.FilterByAsync(r =>
+                    r.Document1Name == header.Document1Name && r.Document1 == header.Document1.Value &&
+                    r.Cancelled == "N" && r.Quantity != null && r.StoresFunction.FunctionCode == "SUKIT" && r.ReqNumber != header.ReqNumber);
+
+                if (reqs.Any())
+                {
+                    var kittedQty = reqs.Sum(r => r.Quantity.GetValueOrDefault());
+
+                    if (kittedQty >= purchaseOrder.OrderQty(header.Document1Line))
+                    {
+                        throw new DocumentException($"Full order qty {purchaseOrder.OrderQty(header.Document1Line)} on order {header.Document1} has already been kitted");
+                    }
+
+                    if (header.Quantity.HasValue)
+                    {
+                        if (kittedQty + header.Quantity > purchaseOrder.OrderQty(header.Document1Line))
+                        {
+                            throw new DocumentException($"Only {purchaseOrder.OrderQty(header.Document1Line) - kittedQty} left to kit for order {header.Document1}");
+                        }
+                    }
+                }
+            }
         }
 
         private static void DoProcessResultCheck(ProcessResult result)

--- a/src/Proxy/HttpClients/DocumentProxy.cs
+++ b/src/Proxy/HttpClients/DocumentProxy.cs
@@ -97,7 +97,13 @@
                            OrderNumber = po.OrderNumber,
                            IsAuthorised = po.AuthorisedBy?.Id != null,
                            IsFilCancelled = !string.IsNullOrEmpty(po.DateFilCancelled),
-                           DocumentType = po.DocumentType?.Name
+                           DocumentType = po.DocumentType?.Name,
+                           Details = po.Details.Select(d => new PurchaseOrderDetailResult
+                           {
+                               Line = d.Line,
+                               OurQty = d.OurQty,
+                               PartNumber = d.PartNumber
+                           })
                        };
         }
 

--- a/src/Resources/External/PurchaseOrderDetailResource.cs
+++ b/src/Resources/External/PurchaseOrderDetailResource.cs
@@ -1,0 +1,11 @@
+﻿namespace Linn.Stores2.Resources.External
+{
+    public class PurchaseOrderDetailResource
+    {
+        public int Line { get; set; }
+
+        public string PartNumber { get; set; }
+
+        public decimal OurQty { get; set; }
+    }
+}

--- a/src/Resources/External/PurchaseOrderResource.cs
+++ b/src/Resources/External/PurchaseOrderResource.cs
@@ -1,4 +1,6 @@
-﻿namespace Linn.Stores2.Resources.External
+﻿using System.Collections.Generic;
+
+namespace Linn.Stores2.Resources.External
 {
     public class PurchaseOrderResource
     {
@@ -9,5 +11,7 @@
         public EmployeeResource AuthorisedBy { get; set; }
         
         public PurchaseOrderTypeResource DocumentType { get; set; }
+
+        public IEnumerable<PurchaseOrderDetailResource> Details { get; set; }
     }
 }

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -585,7 +585,9 @@ function Requisition({ creating }) {
                                         resultsInModal
                                         resultLimit={100}
                                         disabled={!creating || !!formState.lines?.length}
-                                        helperText="<Enter> to search or <Tab> to select"
+                                        helperText={
+                                            creating ? '<Enter> to search or <Tab> to select' : ''
+                                        }
                                         value={formState.storesFunction?.code}
                                         handleValueChange={(_, newVal) => {
                                             dispatch({
@@ -818,6 +820,7 @@ function Requisition({ creating }) {
                                 partSource={formState.storesFunction?.partSource}
                                 onSelectPart={handleDocument1PartSelect}
                                 document1Details={formState.document1Details}
+                                storesFunction={formState.storesFunction}
                             />
                             <Document2
                                 document2={formState.document2}

--- a/src/Service.Host/client/src/components/requisitions/components/Document1.js
+++ b/src/Service.Host/client/src/components/requisitions/components/Document1.js
@@ -15,7 +15,8 @@ function Document1({
     onSelect,
     partSource,
     onSelectPart = null,
-    document1Details = null
+    document1Details = null,
+    storesFunction = null
 }) {
     const displayDetails1 =
         document1Details && partSource === 'WO'
@@ -51,7 +52,10 @@ function Document1({
             onSelect({
                 partNumber: purchaseOrder.details[0].partNumber,
                 partDescription: purchaseOrder.details[0].partDescription,
-                batchRef: `${docType.charAt(0)}${purchaseOrder.orderNumber}`,
+                batchRef:
+                    storesFunction?.batchRequired === 'Y'
+                        ? `${docType.charAt(0)}${purchaseOrder.orderNumber}`
+                        : null,
                 document1Line: 1
             });
             clearPurchaseOrder();

--- a/src/Service.Host/client/src/components/requisitions/components/PartNumberQuantity.js
+++ b/src/Service.Host/client/src/components/requisitions/components/PartNumberQuantity.js
@@ -36,7 +36,9 @@ function PartNumberQuantity({
                     label={partLabel}
                     resultsInModal
                     resultLimit={100}
-                    helperText={disabled ? '' : '<Enter> to search part. <Tab> to select'}
+                    helperText={
+                        disabled || !setPart ? '' : '<Enter> to search part. <Tab> to select'
+                    }
                     value={partNumber}
                     disabled={disabled || !setPart}
                     handleValueChange={(_, newVal) => {

--- a/src/Service.Host/client/src/components/requisitions/components/StockOptions.js
+++ b/src/Service.Host/client/src/components/requisitions/components/StockOptions.js
@@ -219,7 +219,7 @@ function StockOptions({
                     label="To Loc"
                     resultsInModal
                     resultLimit={100}
-                    helperText="<Enter> to search or <Tab> to select"
+                    helperText={disabled ? '' : '<Enter> to search or <Tab> to select'}
                     value={toLocationCode}
                     handleValueChange={setItemValue}
                     search={searchLocations}

--- a/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
+++ b/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
@@ -285,6 +285,7 @@
             {
                 Description = "KIT PARTS TO SUPPLIER STORE",
                 BatchRequired = "N",
+                DepartmentNominalRequired = "N",
                 Document1RequiredFlag = "Y",
                 Document1LineRequiredFlag = "N",
                 Document1Text = "Order Number",
@@ -293,7 +294,16 @@
                 ManualPickRequired = "A",
                 PartSource = "PO",
                 ToLocationRequired = "Y",
-                ToStateRequired = "N"
+                ToStateRequired = "N",
+                TransactionsTypes = new List<StoresFunctionTransaction>
+                {
+                    new StoresFunctionTransaction
+                    {
+                        FunctionCode = "SUKIT",
+                        TransactionDefinition = TestTransDefs.StockToSupplierKit,
+                        TransactionCode = TestTransDefs.StockToSupplierKit.TransactionCode
+                    }
+                }
             };
 
         public static readonly StoresFunction WriteOff =

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderAndFullyKitted.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderAndFullyKitted.cs
@@ -1,0 +1,88 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.External;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    public class WhenCheckingPurchaseOrderAndFullyKitted : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var emp = new Employee { Id = 1, Name = "Jock Bairn" };
+            var part = new Part { PartNumber = "ADIKT", Description = "Cartridge" };
+            var supplierLoc = new StorageLocation { LocationCode = "S-SU-1234", Description = "Supplier Heaven" };
+            var requisitions = new List<RequisitionHeader>
+                                   {
+                                       new RequisitionHeader(
+                                           emp,
+                                           TestFunctionCodes.SupplierKit,
+                                           null,
+                                           1,
+                                           "PO",
+                                           null,
+                                           null,
+                                           part: part,
+                                           quantity: 6,
+                                           toLocation: supplierLoc),
+                                       new RequisitionHeader(
+                                           emp,
+                                           TestFunctionCodes.SupplierKit,
+                                           null,
+                                           1,
+                                           "PO",
+                                           null,
+                                           null,
+                                           part: part,
+                                           quantity: 3,
+                                           toLocation: supplierLoc),
+                                   };
+            var header = new RequisitionHeader(
+                emp,
+                TestFunctionCodes.SupplierKit,
+                null,
+                1,
+                "PO",
+                null,
+                null,
+                part: part,
+                quantity: 1,
+                toLocation: supplierLoc);
+
+            var purchaseOrder = new PurchaseOrderResult
+            {
+                IsAuthorised = true,
+                IsFilCancelled = false,
+                OrderNumber = 1,
+                DocumentType = "PO",
+                Details = new List<PurchaseOrderDetailResult>
+                {
+                    new PurchaseOrderDetailResult { Line = 1, OurQty = 9, PartNumber = "ADIKT" }
+                }
+            };
+
+            this.ReqRepository.FilterByAsync(Arg.Any<Expression<Func<RequisitionHeader, bool>>>())
+                .Returns(requisitions);
+
+            this.action = async () => await this.Sut.CheckPurchaseOrderForOverAndFullyKitted(header, purchaseOrder);
+        }
+
+        [Test]
+        public async Task ShouldThrow()
+        {
+            await this.action.Should().ThrowAsync<DocumentException>().WithMessage($"Full order qty 9 on order 1 has already been kitted");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderForOverKitting.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderForOverKitting.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Linn.Stores2.Domain.LinnApps.Exceptions;
+using Linn.Stores2.Domain.LinnApps.External;
+using Linn.Stores2.Domain.LinnApps.Parts;
+using Linn.Stores2.Domain.LinnApps.Requisitions;
+using Linn.Stores2.Domain.LinnApps.Stock;
+using Linn.Stores2.TestData.FunctionCodes;
+using MimeKit;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    public class WhenCheckingPurchaseOrderForOverKitting : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var emp = new Employee { Id = 1, Name = "Jock Bairn" };
+            var part = new Part { PartNumber = "ADIKT", Description = "Cartridge" };
+            var supplierLoc = new StorageLocation { LocationCode = "S-SU-1234", Description = "Supplier Heaven" };
+            var requisitions = new List<RequisitionHeader>
+                                   {
+                                       new RequisitionHeader(
+                                           emp,
+                                           TestFunctionCodes.SupplierKit,
+                                           null,
+                                           1,
+                                           "PO",
+                                           null,
+                                           null,
+                                           part: part,
+                                           quantity: 4,
+                                           toLocation: supplierLoc)
+                                   };
+            var header = new RequisitionHeader(
+                emp,
+                TestFunctionCodes.SupplierKit,
+                null,
+                1,
+                "PO",
+                null,
+                null,
+                part: part,
+                quantity: 10,
+                toLocation: supplierLoc);
+
+            var purchaseOrder = new PurchaseOrderResult
+            {
+                IsAuthorised = true,
+                IsFilCancelled = false,
+                OrderNumber = 1,
+                DocumentType = "PO",
+                Details = new List<PurchaseOrderDetailResult>
+                {
+                    new PurchaseOrderDetailResult { Line = 1, OurQty = 9, PartNumber = "ADIKT" }
+                }
+            };
+
+            this.ReqRepository.FilterByAsync(Arg.Any<Expression<Func<RequisitionHeader, bool>>>())
+                .Returns(requisitions);
+
+            this.action = async () => await this.Sut.CheckPurchaseOrderForOverAndFullyKitted(header, purchaseOrder);
+        }
+
+        [Test]
+        public async Task ShouldThrow()
+        {
+            await this.action.Should().ThrowAsync<DocumentException>().WithMessage("Only 5 left to kit for order 1");
+        }
+
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderForOverKitting.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenCheckingPurchaseOrderForOverKitting.cs
@@ -1,20 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Linn.Stores2.Domain.LinnApps.Exceptions;
-using Linn.Stores2.Domain.LinnApps.External;
-using Linn.Stores2.Domain.LinnApps.Parts;
-using Linn.Stores2.Domain.LinnApps.Requisitions;
-using Linn.Stores2.Domain.LinnApps.Stock;
-using Linn.Stores2.TestData.FunctionCodes;
-using MimeKit;
-using NSubstitute;
-using NUnit.Framework;
-
-namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.External;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using NSubstitute;
+    using NUnit.Framework;
+
     public class WhenCheckingPurchaseOrderForOverKitting : ContextBase
     {
         private Func<Task> action;

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKit.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKit.cs
@@ -1,0 +1,78 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System.Linq.Expressions;
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Common.Domain;
+    using Linn.Stores2.Domain.LinnApps.External;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using Linn.Stores2.TestData.Transactions;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Collections.Generic;
+
+    public class WhenValidatingSupplierKit : ContextBase
+    {
+        private RequisitionHeader result;
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            this.EmployeeRepository.FindByIdAsync(33087).Returns(new Employee());
+            this.StoresFunctionRepository.FindByIdAsync(TestFunctionCodes.SupplierKit.FunctionCode)
+                .Returns(TestFunctionCodes.SupplierKit);
+            this.ReqStoredProcedures.CanPutPartOnPallet("ADIKT", 666).Returns(true);
+            this.PartRepository.FindByIdAsync("ADIKT").Returns(new Part { PartNumber = "ADIKT" });
+            this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.InspectionToStores.TransactionCode)
+                .Returns(TestTransDefs.InspectionToStores);
+            var loc = new StorageLocation { LocationId = 1, LocationCode = "S-SU-1234" };
+            this.StorageLocationRepository.FindByAsync(Arg.Any<Expression<Func<StorageLocation, bool>>>())
+                .Returns(loc);
+            this.DocumentProxy.GetPurchaseOrder(827753).Returns(
+                new PurchaseOrderResult
+                {
+                    IsAuthorised = true,
+                    IsFilCancelled = false,
+                    OrderNumber = 827753,
+                    DocumentType = "PO",
+                    Details = new List<PurchaseOrderDetailResult>
+                    {
+                        new PurchaseOrderDetailResult { Line = 1, OurQty = 1, PartNumber = "ADIKT" }
+                    }
+                });
+            this.StateRepository.FindByIdAsync("STORES").Returns(new StockState("STORES", "Stores"));
+            this.StockPoolRepository.FindByIdAsync("SUPPLIER").Returns(new StockPool());
+            this.StoresService.ValidOntoLocation(
+                Arg.Any<Part>(),
+                Arg.Any<StorageLocation>(),
+                Arg.Any<StoresPallet>(),
+                Arg.Any<StockState>()).Returns(new ProcessResult(true, null));
+            this.StockService.ValidStockLocation(null, 666, "PART", 10, "QC").Returns(new ProcessResult(true, null));
+            this.result = await this.Sut.Validate(
+                33087,
+                TestFunctionCodes.SupplierKit.FunctionCode,
+                null,
+                827753,
+                null,
+                null,
+                null,
+                null,
+                partNumber: "ADIKT",
+                quantity: 1,
+                fromState: "STORES",
+                toState: "STORES",
+                toLocationCode: "S-SU-1234",
+                toStockPool: "SUPPLIER");
+        }
+
+        [Test]
+        public void ShouldReturnValidated()
+        {
+            this.result.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKitAndOrderAlreadyBeenKitted.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKitAndOrderAlreadyBeenKitted.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using Linn.Stores2.Domain.LinnApps.Requisitions;
-
-namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -11,6 +9,7 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
     using Linn.Stores2.Domain.LinnApps.Exceptions;
     using Linn.Stores2.Domain.LinnApps.External;
     using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
     using Linn.Stores2.Domain.LinnApps.Stock;
     using Linn.Stores2.TestData.FunctionCodes;
     using Linn.Stores2.TestData.Transactions;

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKitAndOrderAlreadyBeenKitted.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingSupplierKitAndOrderAlreadyBeenKitted.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using Linn.Stores2.Domain.LinnApps.Requisitions;
+
+namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Common.Domain;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.External;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using Linn.Stores2.TestData.Transactions;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    public class WhenValidatingSupplierKitAndOrderAlreadyBeenKitted : ContextBase
+    {
+        private Func<Task> act;
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            this.EmployeeRepository.FindByIdAsync(33087).Returns(new Employee());
+            this.StoresFunctionRepository.FindByIdAsync(TestFunctionCodes.SupplierKit.FunctionCode)
+                .Returns(TestFunctionCodes.SupplierKit);
+            this.ReqStoredProcedures.CanPutPartOnPallet("ADIKT", 666).Returns(true);
+            var part = new Part { PartNumber = "ADIKT" };
+            this.PartRepository.FindByIdAsync("ADIKT").Returns(part);
+            this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.InspectionToStores.TransactionCode)
+                .Returns(TestTransDefs.InspectionToStores);
+            var loc = new StorageLocation { LocationId = 1, LocationCode = "S-SU-1234" };
+            this.StorageLocationRepository.FindByAsync(Arg.Any<Expression<Func<StorageLocation, bool>>>())
+                .Returns(loc);
+            this.DocumentProxy.GetPurchaseOrder(827753).Returns(
+                new PurchaseOrderResult
+                {
+                    IsAuthorised = true,
+                    IsFilCancelled = false,
+                    OrderNumber = 827753,
+                    DocumentType = "PO",
+                    Details = new List<PurchaseOrderDetailResult>
+                    {
+                        new PurchaseOrderDetailResult { Line = 1, OurQty = 1, PartNumber = "ADIKT" }
+                    }
+                });
+            this.StateRepository.FindByIdAsync("STORES").Returns(new StockState("STORES", "Stores"));
+            this.StockPoolRepository.FindByIdAsync("SUPPLIER").Returns(new StockPool());
+            this.StoresService.ValidOntoLocation(
+                Arg.Any<Part>(),
+                Arg.Any<StorageLocation>(),
+                Arg.Any<StoresPallet>(),
+                Arg.Any<StockState>()).Returns(new ProcessResult(true, null));
+            this.StockService.ValidStockLocation(null, 666, "PART", 10, "QC").Returns(new ProcessResult(true, null));
+
+            var requisitions = new List<RequisitionHeader>
+            {
+                new RequisitionHeader(
+                    new Employee(),
+                    TestFunctionCodes.SupplierKit,
+                    null,
+                    1,
+                    "PO",
+                    null,
+                    null,
+                    part: part,
+                    quantity: 6,
+                    toLocation: loc),
+                new RequisitionHeader(
+                    new Employee(),
+                    TestFunctionCodes.SupplierKit,
+                    null,
+                    1,
+                    "PO",
+                    null,
+                    null,
+                    part: part,
+                    quantity: 3,
+                    toLocation: loc),
+            };
+            this.ReqRepository.FilterByAsync(Arg.Any<Expression<Func<RequisitionHeader, bool>>>())
+                .Returns(requisitions);
+
+            this.act = () => this.Sut.Validate(
+                33087,
+                TestFunctionCodes.SupplierKit.FunctionCode,
+                null,
+                827753,
+                "PO",
+                null,
+                null,
+                null,
+                partNumber: "ADIKT",
+                quantity: 1,
+                fromState: "STORES",
+                toState: "STORES",
+                toLocationCode: "S-SU-1234",
+                toStockPool: "SUPPLIER");
+        }
+
+        [Test]
+        public async Task ShouldThrow()
+        {
+            await this.act.Should().ThrowAsync<DocumentException>()
+                .WithMessage("Full order qty 1 on order 827753 has already been kitted");
+        }
+    }
+}


### PR DESCRIPTION
SUKIT

new features
- STORES_OO.ORDER_CAN_BE_KITTED now in c#
- Failing on auto book now tries to cancel req header as having unbooked reqs mucks up validation checks around how much can be kitted
- SUKIT currently to assume you always want purchase order line 1 but wanted to leave it open in future to go properly multi line on purchase orders