### PR TITLE
complain if no onto for move

### DIFF
--- a/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/IRequisitionManager.cs
@@ -72,7 +72,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             string isReverseTransaction = "N",
             int? originalDocumentNumber = null);
 
-        Task<RequisitionLine> ValidateLineCandidate(LineCandidate candidate);
+        Task<RequisitionLine> ValidateLineCandidate(LineCandidate candidate, StoresFunction storesFunction = null);
 
         Task<DocumentResult> GetDocument(string docName, int docNumber, int? lineNumber);
 

--- a/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
+++ b/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
@@ -399,6 +399,7 @@
                     ToStateRequired = "O",
                     ToStockPoolRequired = "O",
                     CanBeReversed = "N",
+                    ToLocationRequired = "O",
                     TransactionsTypes = new List<StoresFunctionTransaction>
                                             {
                                                 new StoresFunctionTransaction

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingOnToLocation.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingOnToLocation.cs
@@ -1,0 +1,63 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using FluentAssertions;
+
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using Linn.Stores2.TestData.Transactions;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenValidatingAndMoveMissingOnToLocation : ContextBase
+    {
+        private Func<Task> action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.DepartmentRepository.FindByIdAsync("1607")
+                .Returns(new Department("1607", "DESC"));
+            this.NominalRepository.FindByIdAsync("2963")
+                .Returns(new Nominal("2963", "DESC"));
+            this.EmployeeRepository.FindByIdAsync(33087).Returns(new Employee());
+            this.StoresFunctionRepository.FindByIdAsync(TestFunctionCodes.Move.FunctionCode)
+                .Returns(TestFunctionCodes.Move);
+            var part = new Part { PartNumber = "PART" };
+            this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
+            this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StockToLinnDept.TransactionCode)
+                .Returns(TestTransDefs.StockToLinnDept);
+            this.action = () => this.Sut.Validate(
+                33087,
+                TestFunctionCodes.Move.FunctionCode,
+                "F",
+                null,
+                null,
+                "1607",
+                "2963",
+                new LineCandidate
+                    {
+                        PartNumber = part.PartNumber,
+                        Qty = 1,
+                        TransactionDefinition = TestTransDefs.StockToLinnDept.TransactionCode,
+                        Moves = new List<MoveSpecification> { new MoveSpecification { Qty = 1, FromPallet = 2345 } }
+                    });
+        }
+
+        [Test]
+        public async Task ShouldThrowException()
+        {
+            await this.action.Should()
+                .ThrowAsync<RequisitionException>().WithMessage(
+                    "You must provide a to location or pallet");
+        }
+    }
+}


### PR DESCRIPTION
usual problem with it not complaining if onto is optional between header and line. 
was allowing moves with no onto to be saved. 
Dunno if this breaks anything for other transactions...