### PR TITLE
fixes for things Ewan noticed

### DIFF
--- a/src/Facade/Services/StorageLocationService.cs
+++ b/src/Facade/Services/StorageLocationService.cs
@@ -47,7 +47,7 @@
 
         protected override Expression<Func<StorageLocation, bool>> SearchExpression(string searchTerm)
         {
-            return l => l.DateInvalid == null && l.LocationCode.Contains(searchTerm.ToUpper());
+            return l => l.DateInvalid == null && (l.LocationCode.Contains(searchTerm.ToUpper()) || l.Description.Contains(searchTerm.ToUpper()));
         }
 
         protected override Task SaveToLogTable(

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -6,6 +6,8 @@ import Grid from '@mui/material/Grid';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import {
@@ -731,7 +733,7 @@ function Requisition({ creating }) {
                                         resultLimit={100}
                                         disabled={!creating || !!formState.req.lines?.length}
                                         helperText={
-                                            creating
+                                            creating && !formState.req.storesFunction?.description
                                                 ? 'Enter a value and press <Enter> to search or <Tab> to select. Alternatively press <Enter> with no input to list all functions'
                                                 : ''
                                         }
@@ -1246,6 +1248,7 @@ function Requisition({ creating }) {
                                             dispatch({ type: 'add_line' });
                                         }}
                                         pickStock={(lineNumber, stockMoves) => {
+                                            setChangesMade(true);
                                             dispatch({
                                                 type: 'pick_stock',
                                                 payload: { lineNumber, stockMoves }
@@ -1391,6 +1394,19 @@ function Requisition({ creating }) {
                                         navigate('/requisitions');
                                     }}
                                 />
+                                {changesMade && !validated && (
+                                    <Stack direction="row" spacing={2}>
+                                        <Chip
+                                            label="Invalid to Save"
+                                            color="error"
+                                            size="small"
+                                            variant="outlined"
+                                        />
+                                        <Typography variant="caption">
+                                            {validToSaveMessage()}
+                                        </Typography>
+                                    </Stack>
+                                )}
                             </Grid>
                             {pickRequisitionDialogVisible && (
                                 <PickRequisitionDialog


### PR DESCRIPTION
fixes for the easy stuff Ewan spotted

QOL improvements - show invalid to save message at bottom
ability to search locations by description for Ewan e.g. METRO was coming up blank as search only on loc
fix that picking stock on LDREQ, LOAN OUT etc req with no other changes was showing as no changes to save