### PR TITLE
moving comments/reference around

### DIFF
--- a/src/Domain.LinnApps/Requisitions/CreationStrategies/LdreqCreationStrategy.cs
+++ b/src/Domain.LinnApps/Requisitions/CreationStrategies/LdreqCreationStrategy.cs
@@ -147,8 +147,8 @@
                 var transactionDefinition = await this.transactionDefinitionRepository
                                                 .FindByIdAsync(context.Lines.First().TransactionDefinition);
                 req.SetStateAndCategory(
-                    transactionDefinition.FromState, 
-                    transactionDefinition.InspectedState, 
+                    req.FromState ?? transactionDefinition.FromState, 
+                    req.ToState ?? transactionDefinition.InspectedState, 
                     transactionDefinition.OntoCategory,
                     transactionDefinition.FromCategory); 
             }

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -963,7 +963,7 @@ function Requisition({ creating }) {
                                             />
                                         )}
                                     </Grid>
-                                    <Grid size={2}>
+                                    <Grid size={4}>
                                         {shouldRender(requiresDepartmentNominal) && (
                                             <Dropdown
                                                 fullWidth
@@ -980,7 +980,7 @@ function Requisition({ creating }) {
                                             />
                                         )}
                                     </Grid>
-                                    <Grid size={8} />
+                                    <Grid size={6} />
                                 </>
                             )}
                             <AuditLocationSearch
@@ -1002,6 +1002,30 @@ function Requisition({ creating }) {
                                     })
                                 }
                             />
+                            <Grid size={6}>
+                                <InputField
+                                    fullWidth
+                                    value={formState.req.reference}
+                                    onChange={handleHeaderFieldChange}
+                                    disabled={
+                                        formState.req?.cancelled === 'Y' ||
+                                        formState.req?.dateBooked
+                                    }
+                                    label="Reference"
+                                    propertyName="reference"
+                                />
+                            </Grid>
+                            <Grid size={6}>
+                                <InputField
+                                    fullWidth
+                                    value={formState.req.comments}
+                                    onChange={(propertyName, newValue) => {
+                                        handleHeaderFieldChange(propertyName, newValue);
+                                    }}
+                                    label="Comments"
+                                    propertyName="comments"
+                                />
+                            </Grid>
                             <Document1
                                 document1={formState.req.document1}
                                 document1Text={formState.req.storesFunction?.document1Text}
@@ -1169,30 +1193,6 @@ function Requisition({ creating }) {
                                     );
                                 })}
                             />
-                            <Grid size={6}>
-                                <InputField
-                                    fullWidth
-                                    value={formState.req.reference}
-                                    onChange={handleHeaderFieldChange}
-                                    disabled={
-                                        formState.req?.cancelled === 'Y' ||
-                                        formState.req?.dateBooked
-                                    }
-                                    label="Reference"
-                                    propertyName="reference"
-                                />
-                            </Grid>
-                            <Grid size={6}>
-                                <InputField
-                                    fullWidth
-                                    value={formState.req.comments}
-                                    onChange={(propertyName, newValue) => {
-                                        handleHeaderFieldChange(propertyName, newValue);
-                                    }}
-                                    label="Comments"
-                                    propertyName="comments"
-                                />
-                            </Grid>
                             {shouldRender(
                                 () => formState.req.storesFunction?.receiptDateRequired === 'Y'
                             ) && (

--- a/src/Service.Host/client/src/components/requisitions/SearchRequisitions.js
+++ b/src/Service.Host/client/src/components/requisitions/SearchRequisitions.js
@@ -99,6 +99,7 @@ function SearchRequisitions() {
         },
         { field: 'created', headerName: 'Created', width: 120 },
         { field: 'createdByName', headerName: 'By', width: 200 },
+        { field: 'functionCode', headerName: 'Function', width: 150 },
         { field: 'doc1', headerName: 'Doc1', width: 110 },
         { field: 'comments', headerName: 'Comments', width: 300 }
     ];
@@ -225,7 +226,8 @@ function SearchRequisitions() {
                                 ...r,
                                 id: r.reqNumber,
                                 created: moment(r.dateCreated).format('DD-MMM-YYYY'),
-                                doc1: `${r.document1Name} ${r.document1}`
+                                doc1: `${r.document1Name ? r.document1Name : ''} ${r.document1 ? r.document1 : ''}`,
+                                functionCode: r.storesFunction?.code
                             })) || []
                         }
                         columns={columns}

--- a/src/Service.Host/client/src/components/requisitions/components/StockOptions.js
+++ b/src/Service.Host/client/src/components/requisitions/components/StockOptions.js
@@ -133,7 +133,9 @@ function StockOptions({
                             label="From Loc"
                             resultsInModal
                             resultLimit={100}
-                            helperText="<Enter> to search or <Tab> to select"
+                            helperText={
+                                fromLocationCode ? '' : '<Enter> to search or <Tab> to select'
+                            }
                             value={fromLocationCode}
                             handleValueChange={setItemValue}
                             disabled={disabled}
@@ -239,7 +241,11 @@ function StockOptions({
                             label="To Loc"
                             resultsInModal
                             resultLimit={100}
-                            helperText={disabled ? '' : '<Enter> to search or <Tab> to select'}
+                            helperText={
+                                disabled || toLocationCode
+                                    ? ''
+                                    : '<Enter> to search or <Tab> to select'
+                            }
                             value={toLocationCode}
                             handleValueChange={setItemValue}
                             search={searchLocations}


### PR DESCRIPTION
fixes issue #272 about from state not persisting on WOFF QC
put function code in search results
get rid of NULL in document column of search results fix issue with WOFF QC throwing away From State
move comments/reference up the page