### PR TITLE
recent checks seem to mess up really old reqs from pending reqs screen

### DIFF
--- a/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
@@ -188,20 +188,23 @@
                 return new ProcessResult(true, "No moves required.");
             }
 
-            var moveQty = this.Moves.Sum(m => m.Quantity);
+            var moveQty = this.Moves?.Sum(m => m.Quantity) ?? 0;
             if (moveQty != this.Qty)
             {
                 return new ProcessResult(false, $"Line quantity ({this.Qty}) does not match moves quantity ({moveQty}).");
             }
 
-            foreach (var reqMove in this.Moves)
+            if (this.Moves != null)
             {
-                if (!reqMove.IsBooked() && !reqMove.IsCancelled())
+                foreach (var reqMove in this.Moves)
                 {
-                    var canBeBooked = reqMove.MoveCanBeBooked(this.TransactionDefinition);
-                    if (!canBeBooked.Success)
+                    if (!reqMove.IsBooked() && !reqMove.IsCancelled())
                     {
-                        return canBeBooked;
+                        var canBeBooked = reqMove.MoveCanBeBooked(this.TransactionDefinition);
+                        if (!canBeBooked.Success)
+                        {
+                            return canBeBooked;
+                        }
                     }
                 }
             }
@@ -254,7 +257,7 @@
 
         public bool StockPicked()
         {
-            if (!this.IsBooked() && !this.IsCancelled() && this.Qty > 0 && this.TransactionDefinition.RequiresStockAllocations)
+            if (!this.IsBooked() && !this.IsCancelled() && this.Qty > 0 && this.Moves != null && this.TransactionDefinition.RequiresStockAllocations)
             {
                 var totalQtyAllocated =
                     this.Moves.Where(m => m.StockLocator != null && !m.IsBooked() && !m.IsCancelled()).Sum(m => m.Quantity);


### PR DESCRIPTION
notice pending reqs broke by recent moves checks including the ones i just added today so this handles Moves =  null better so that reqs can be displayed