### PR TITLE
fix moveloc canbook bug

### DIFF
--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -555,8 +555,13 @@
         {
             if (!this.IsBooked() && !this.IsCancelled() && this.StoresFunction != null)
             {
-                var canBeBooked = this.RequisitionCanBeBooked(lineNumber);
-                return canBeBooked.Success;
+                if (this.StoresFunction.LinesRequired != "N")
+                {
+                    var canBeBooked = this.RequisitionCanBeBooked(lineNumber);
+                    return canBeBooked.Success;
+                }
+                // moveloc don't need no lines
+                return true;
             }
 
             return false;
@@ -617,6 +622,10 @@
             else if (this.StoresFunction.AuditFunction())
             {
                 return new ProcessResult(true, "Audit functions don't need lines.");
+            }
+            else if (this.StoresFunction.NoLinesRequiredFunction())
+            {
+                return new ProcessResult(true, $"{this.StoresFunction.FunctionCode} functions don't need lines.");
             }
             else if (this.Part != null)
             {

--- a/src/Domain.LinnApps/Requisitions/StoresFunction.cs
+++ b/src/Domain.LinnApps/Requisitions/StoresFunction.cs
@@ -81,7 +81,11 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
 
         public string LinesRequired { get; set;  }
 
+        public bool NoLinesRequiredFunction() => this.LinesRequired == "N";
+
         public bool AuditFunction() => this.FunctionCode == "AUDIT" || this.FunctionCode == "KOUNT";
+
+
 
         public bool Document1Required() => this.Document1RequiredFlag is "Y" or "O" or "X";
 

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/CanBookTests/WhenTryingToBookAndMoveLocFunction.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/CanBookTests/WhenTryingToBookAndMoveLocFunction.cs
@@ -1,0 +1,36 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionHeaderTests.CanBookTests
+{
+    using FluentAssertions;
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using NUnit.Framework;
+
+    public class WhenTryingToBookAndMoveLocFunction : CanBookContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Sut = new RequisitionHeader(
+                new Employee(),
+                TestFunctionCodes.MoveLocation,
+                "F",
+                12345678,
+                "TYPE",
+                new Department(),
+                new Nominal(),
+                reference: null,
+                comments: "shipping",
+                fromPalletNumber: 1742,
+                toPalletNumber: 1740);
+
+            this.Result = this.Sut.RequisitionCanBeBooked();
+        }
+
+        [Test]
+        public void ShouldBeAbleToBook()
+        {
+            this.Result.Success.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
the MOVELOC function were failing the can book checks because (like AUDIT) they don't need no lines (the book req does it for them)