### PR TITLE
allow MOVELOC to have a To Stock Pool but not a part

### DIFF
--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -1642,7 +1642,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                     "O"));
             }
 
-            if (!string.IsNullOrEmpty(header.ToStockPool))
+            if (!string.IsNullOrEmpty(header.ToStockPool) && header.StoresFunction.PartNumberRequired()) 
             {
                 DoProcessResultCheck(this.storesService.ValidStockPool(header.Part, stockPool));
             }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingMoveLocWithToStockPool.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingMoveLocWithToStockPool.cs
@@ -1,0 +1,50 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+{
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Linn.Common.Domain;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stock;
+    using Linn.Stores2.TestData.FunctionCodes;
+    using Linn.Stores2.TestData.Transactions;
+    using MimeKit;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    public class WhenValidatingMoveLocWithToStockPool : ContextBase
+    {
+        private RequisitionHeader result;
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            this.EmployeeRepository.FindByIdAsync(33087).Returns(new Employee());
+            this.StoresFunctionRepository.FindByIdAsync(TestFunctionCodes.MoveLocation.FunctionCode)
+                .Returns(TestFunctionCodes.MoveLocation);
+            this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.CustomerToGoodStock.TransactionCode)
+                .Returns(TestTransDefs.CustomerToGoodStock);
+            this.PalletRepository.FindByIdAsync(502).Returns(new StoresPallet());
+            this.PalletRepository.FindByIdAsync(503).Returns(new StoresPallet());
+            this.StockPoolRepository.FindByIdAsync("LINN").Returns(new StockPool { StockPoolCode = "LINN" });
+            this.StockService.ValidStockLocation(null, 502, Arg.Any<string>(), Arg.Any<decimal>(), Arg.Any<string>())
+                .Returns(new ProcessResult(true, null));
+            this.result = await this.Sut.Validate(
+                33087,
+                TestFunctionCodes.MoveLocation.FunctionCode,
+                null,
+                null,
+                null,
+                null,
+                null,
+                fromPalletNumber: 502,
+                toPalletNumber: 503,
+                toStockPool: "LINN");
+        }
+
+        [Test]
+        public void ShouldReturnValidated()
+        {
+            this.result.Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
To fix Colin issue where MOVELOC didn't work if you put in a stock pool as it doesn't require a part given the stock pool check requires a part