### PR TITLE
Dept change postings

### DIFF
--- a/src/Domain.LinnApps/Exceptions/InvalidNominalAccountException.cs
+++ b/src/Domain.LinnApps/Exceptions/InvalidNominalAccountException.cs
@@ -1,0 +1,17 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Exceptions
+{
+    using System;
+
+    using Linn.Common.Domain.Exceptions;
+
+    public class InvalidNominalAccountException : DomainException
+    {
+        public InvalidNominalAccountException(string message) : base(message)
+        {
+        }
+
+        public InvalidNominalAccountException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -414,8 +414,8 @@
                     throw new RequisitionException("Cannot change department on a reverse transaction");
                 }
 
-                // just for now
-                // since we know these transactions have a fixed credit nomacc
+                // a temporary defensive measure to prevent widespread problems
+                // if i'm getting this wrong
                 var functionCodesDepartmentCanBeChangedFor = new List<string> { "WOFF", "WOFF QC" };
 
                 if (functionCodesDepartmentCanBeChangedFor.Contains(this.StoresFunction.FunctionCode))
@@ -426,6 +426,11 @@
                     {
                         
                     }
+                }
+                else
+                {
+                    throw new RequisitionException(
+                        $"Can't currently change department for {this.StoresFunction.FunctionCode}");
                 }
             }
         }

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -424,7 +424,7 @@
                     
                     foreach (var requisitionLine in this.Lines)
                     {
-                        
+                        requisitionLine.ApplyNominalAccountUpdate(nominalAccount);
                     }
                 }
                 else

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -415,7 +415,7 @@
                 }
 
                 // a temporary defensive measure to prevent more widespread problems
-                // if i'm getting any of this wrong
+                // just in case any of the following updating nominal accounts code is wrong
                 var functionCodesDepartmentCanBeChangedFor = new List<string> { "WOFF", "WOFF QC" };
 
                 if (functionCodesDepartmentCanBeChangedFor.Contains(this.StoresFunction.FunctionCode))

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -414,8 +414,8 @@
                     throw new RequisitionException("Cannot change department on a reverse transaction");
                 }
 
-                // a temporary defensive measure to prevent widespread problems
-                // if i'm getting this wrong
+                // a temporary defensive measure to prevent more widespread problems
+                // if i'm getting any of this wrong
                 var functionCodesDepartmentCanBeChangedFor = new List<string> { "WOFF", "WOFF QC" };
 
                 if (functionCodesDepartmentCanBeChangedFor.Contains(this.StoresFunction.FunctionCode))

--- a/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionHeader.cs
@@ -415,6 +415,7 @@
                 }
 
                 // just for now
+                // since we know these transactions have a fixed credit nomacc
                 var functionCodesDepartmentCanBeChangedFor = new List<string> { "WOFF", "WOFF QC" };
 
                 if (functionCodesDepartmentCanBeChangedFor.Contains(this.StoresFunction.FunctionCode))
@@ -423,7 +424,7 @@
                     
                     foreach (var requisitionLine in this.Lines)
                     {
-                        // update nominal posting for line
+                        
                     }
                 }
             }

--- a/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
@@ -267,7 +267,7 @@
             return false;
         }
 
-        public void UpdateNominalAccount(NominalAccount newNominalAccount)
+        public void ApplyNominalAccountUpdate(NominalAccount newNominalAccount)
         {
             if (this.IsBooked())
             {

--- a/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionLine.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Xml.Linq;
 
     using Linn.Common.Domain;
     using Linn.Stores2.Domain.LinnApps.Accounts;

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -644,7 +644,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                 throw new UnauthorisedActionException(
                     $"You are not authorised to make changes to {current.StoresFunction.FunctionCode} reqs");
             }
-
+            
             var dept = current.Department;
 
             if (updatedDepartmentNumber != current.Department?.DepartmentCode)
@@ -660,11 +660,10 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                     throw new RequisitionException("Department Code not valid for selected Nominal Code");
                 }
 
-                dept = updatedDepartment;
+                // look up nominal account
             }
-
-
-            current.Update(updatedComments, updatedReference, dept);
+            
+            current.Update(updatedComments, updatedReference);
 
 
             foreach (var line in lineUpdates)

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -279,7 +279,6 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
             var moveSpecifications = moves.ToList();
             await this.CheckMoves(line.Part.PartNumber, moveSpecifications);
             
-            // only implementing moves onto for now
             foreach (var moveOnto
                      in moveSpecifications.Where(x => x.ToPallet.HasValue || !string.IsNullOrEmpty(x.ToLocation)))
             {
@@ -453,7 +452,6 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                 var insertOrUpdateMoves = "I";
                 if (header.ManualPick == "N" && transactionDefinition.RequiresStockAllocations)
                 {
-                    // todo can we make automatic from picks see CREATE_REQ_MOVES in REQ_UT.fmb
                     var autopickResult = await this.requisitionStoredProcedures.PickStock(
                         toAdd.PartNumber,
                         header.ReqNumber,
@@ -472,7 +470,6 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                     }
                 }
                 
-                // todo what about the ontos
                 if (transactionDefinition.RequiresOntoTransactions)
                 {
                     var ontoResult = await this.requisitionStoredProcedures.InsertReqOntos(
@@ -493,8 +490,6 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                 }
             }
 
-            // todo - consider what has to happen if a move is from one place to another
-            // i.e. cases where both a 'from' and a 'to' location or pallet is set
             var createPostingsResult = await this.requisitionStoredProcedures.CreateNominals(
                                            header.ReqNumber,
                                            toAdd.Qty,
@@ -645,22 +640,15 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                     $"You are not authorised to make changes to {current.StoresFunction.FunctionCode} reqs");
             }
             
-            var dept = current.Department;
-
             if (updatedDepartmentNumber != current.Department?.DepartmentCode)
             {
                 var updatedDepartment = await this.departmentRepository.FindByIdAsync(updatedDepartmentNumber);
 
-                var isValid = await this.storesService.ValidDepartmentNominal(
+                var newNomAcc = await this.storesService.ValidNominalAccount(
                                   updatedDepartment.DepartmentCode,
                                   current.Nominal.NominalCode);
 
-                if (!isValid.Success)
-                {
-                    throw new RequisitionException("Department Code not valid for selected Nominal Code");
-                }
-
-                // look up nominal account
+                current.ApplyNominalAccountChange(newNomAcc);
             }
             
             current.Update(updatedComments, updatedReference);
@@ -829,10 +817,9 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
 
             if (req.Department != null && req.Nominal != null)
             {
-                DoProcessResultCheck(
-                    await this.storesService.ValidDepartmentNominal(
+                    await this.storesService.ValidNominalAccount(
                         req.Department.DepartmentCode,
-                        req.Nominal.NominalCode));
+                        req.Nominal.NominalCode);
             }
 
             if (!string.IsNullOrEmpty(auditLocation))
@@ -1454,10 +1441,9 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
 
             foreach (var bookInOrderDetail in bookInOrderDetails)
             {
-                DoProcessResultCheck(
-                    await this.storesService.ValidDepartmentNominal(
+                    await this.storesService.ValidNominalAccount(
                         bookInOrderDetail.DepartmentCode,
-                        bookInOrderDetail.NominalCode));
+                        bookInOrderDetail.NominalCode);
             }
         }
 

--- a/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
+++ b/src/Domain.LinnApps/Requisitions/RequisitionManager.cs
@@ -648,7 +648,7 @@ namespace Linn.Stores2.Domain.LinnApps.Requisitions
                                   updatedDepartment.DepartmentCode,
                                   current.Nominal.NominalCode);
 
-                current.ApplyNominalAccountChange(newNomAcc);
+                current.ApplyNominalAccountChange(newNomAcc); // todo - test
             }
             
             current.Update(updatedComments, updatedReference);

--- a/src/Domain.LinnApps/Requisitions/StoresTransactionPosting.cs
+++ b/src/Domain.LinnApps/Requisitions/StoresTransactionPosting.cs
@@ -23,5 +23,9 @@
         public string DebitOrCredit { get; set; }
 
         public Nominal Nominal { get; set; }
+
+        public string NominalRule { get; set; }
+
+        public string DepartmentRule { get; set; }
     }
 }

--- a/src/Domain.LinnApps/Stores/IStoresService.cs
+++ b/src/Domain.LinnApps/Stores/IStoresService.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using Linn.Common.Domain;
+    using Linn.Stores2.Domain.LinnApps.Accounts;
     using Linn.Stores2.Domain.LinnApps.Parts;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
     using Linn.Stores2.Domain.LinnApps.Stock;
@@ -32,7 +33,7 @@
         Task<ProcessResult> ValidReverseQuantity(int originalReqNumber, decimal quantity);
 
         // stores_oo.valid_dept_nom
-        Task<ProcessResult> ValidDepartmentNominal(string departmentCode, string nominalCode);
+        Task<NominalAccount> ValidNominalAccount(string departmentCode, string nominalCode);
 
         // stores_oo.default_bookin_location
         Task<StorageLocation> DefaultBookInLocation(string partNumber);

--- a/src/Domain.LinnApps/Stores/StoresService.cs
+++ b/src/Domain.LinnApps/Stores/StoresService.cs
@@ -312,6 +312,7 @@
             return new ProcessResult(true, $"Reverse quantity of {quantity} for req {originalReqNumber} is valid");
         }
 
+        // maybe refactor to return the nominal account too? a tuple? or just the nomacc if valiud, throw if not with the message?
         public async Task<ProcessResult> ValidDepartmentNominal(string departmentCode, string nominalCode)
         {
             // stores_oo.valid_dept_nom

--- a/src/Domain.LinnApps/Stores/StoresService.cs
+++ b/src/Domain.LinnApps/Stores/StoresService.cs
@@ -7,6 +7,7 @@
     using Linn.Common.Domain;
     using Linn.Common.Persistence;
     using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
     using Linn.Stores2.Domain.LinnApps.Parts;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
     using Linn.Stores2.Domain.LinnApps.Stock;
@@ -313,7 +314,7 @@
         }
 
         // maybe refactor to return the nominal account too? a tuple? or just the nomacc if valiud, throw if not with the message?
-        public async Task<ProcessResult> ValidDepartmentNominal(string departmentCode, string nominalCode)
+        public async Task<NominalAccount> ValidNominalAccount(string departmentCode, string nominalCode)
         {
             // stores_oo.valid_dept_nom
             var nominalAccount = await this.nominalAccountRepository.FindByAsync(a =>
@@ -321,15 +322,15 @@
 
             if (nominalAccount == null)
             {
-                return new ProcessResult(false, $"Department / Nominal {departmentCode} / { nominalCode} are not a valid combination");
+                throw new InvalidNominalAccountException($"Department / Nominal {departmentCode} / { nominalCode} are not a valid combination");
             }
 
             if (nominalAccount.StoresPostsAllowed != "Y")
             {
-                return new ProcessResult(false, $"Department / Nominal {departmentCode} / {nominalCode} are not a valid for stores posting");
+                throw new InvalidNominalAccountException($"Department / Nominal {departmentCode} / {nominalCode} are not a valid for stores posting");
             }
 
-            return new ProcessResult(true, $"Department / Nominal {departmentCode} / {nominalCode} are a valid combination for stores");
+            return nominalAccount;
         }
 
         public async Task<StorageLocation> DefaultBookInLocation(string partNumber)

--- a/src/Persistence.LinnApps/Repositories/RequisitionRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/RequisitionRepository.cs
@@ -32,7 +32,7 @@
                 .ThenInclude(d => d.TransactionDefinition)
                 .ThenInclude(d => d.StoresTransactionStates)
                 .Include(r => r.Lines).ThenInclude(l => l.Part)
-                .Include(r => r.Lines).ThenInclude(l => l.TransactionDefinition)
+                .Include(r => r.Lines).ThenInclude(l => l.TransactionDefinition).ThenInclude(d => d.StoresTransactionPostings)
                 .Include(r => r.Lines).ThenInclude(l => l.NominalAccountPostings).ThenInclude(p => p.NominalAccount)
                 .ThenInclude(a => a.Nominal)
                 .Include(r => r.Lines).ThenInclude(l => l.NominalAccountPostings).ThenInclude(p => p.NominalAccount)

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -819,6 +819,8 @@
             e.Property(s => s.TransactionCode).HasColumnName("TRANSACTION_CODE").HasMaxLength(10);
             e.Property(s => s.DebitOrCredit).HasColumnName("DEBIT_OR_CREDIT").HasMaxLength(1);
             e.HasOne(r => r.Nominal).WithMany().HasForeignKey("NOMINAL");
+            e.Property(s => s.NominalRule).HasColumnName("NOM_RULE").HasMaxLength(maxLength: 16);
+            e.Property(s => s.DepartmentRule).HasColumnName("DEPT_RULE").HasMaxLength(maxLength: 16);
         }
 
         private static void BuildPotentialMoveDetails(ModelBuilder builder)

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -930,7 +930,7 @@ function Requisition({ creating }) {
                             </Grid>
                             <Grid size={2} />
                             <DepartmentNominal
-                                disabled={!creating}
+                                // disabled={!creating}
                                 departmentCode={formState.req.department?.departmentCode}
                                 departmentDescription={formState.req.department?.description}
                                 setDepartment={newDept => {

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -218,8 +218,6 @@ function Requisition({ creating }) {
 
     const [revertState, setRevertState] = useState({});
 
-    console.log(updateResult);
-
     useEffect(() => {
         if (creating && !hasLoadedDefaultState && userNumber) {
             setHasFetched(false);
@@ -257,7 +255,6 @@ function Requisition({ creating }) {
             clearReqResult();
         }
         if (updateResult) {
-            console.log(updateResult);
             dispatch({ type: 'load_state', payload: updateResult });
             setRevertState(updateResult);
             clearUpdateResult();

--- a/src/Service.Host/client/src/components/requisitions/Requisition.js
+++ b/src/Service.Host/client/src/components/requisitions/Requisition.js
@@ -187,7 +187,7 @@ function Requisition({ creating }) {
         errorMessage: updateError,
         postResult: updateResult,
         clearPostResult: clearUpdateResult
-    } = usePost(itemTypes.requisitions.url, true, true);
+    } = usePost(itemTypes.requisitions.url, true, false);
 
     const [tab, setTab] = useState(0);
     const [selectedLine, setSelectedLine] = useState(1);
@@ -217,6 +217,8 @@ function Requisition({ creating }) {
     const [hasLoadedDefaultState, setHasLoadedDefaultState] = useState(false);
 
     const [revertState, setRevertState] = useState({});
+
+    console.log(updateResult);
 
     useEffect(() => {
         if (creating && !hasLoadedDefaultState && userNumber) {
@@ -255,6 +257,7 @@ function Requisition({ creating }) {
             clearReqResult();
         }
         if (updateResult) {
+            console.log(updateResult);
             dispatch({ type: 'load_state', payload: updateResult });
             setRevertState(updateResult);
             clearUpdateResult();

--- a/src/Service.Host/client/src/components/requisitions/reducers/requisitonReducer.js
+++ b/src/Service.Host/client/src/components/requisitions/reducers/requisitonReducer.js
@@ -17,6 +17,7 @@ function reducer(state, action) {
             }
 
             if (newState.reqNumber) {
+                // console.log(newState);
                 return { ...state, req: newState, document1Details: newState.document1Details };
             } else {
                 return { ...state, req: { ...state.req, links: newState.links } };

--- a/src/Service.Host/package-lock.json
+++ b/src/Service.Host/package-lock.json
@@ -269,13 +269,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/types": "^7.28.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -363,9 +363,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+            "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -404,9 +404,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-            "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -707,9 +707,9 @@
             "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
-            "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+            "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
             "cpu": [
                 "ppc64"
             ],
@@ -724,9 +724,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
-            "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+            "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
             "cpu": [
                 "arm"
             ],
@@ -741,9 +741,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
-            "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+            "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
             "cpu": [
                 "arm64"
             ],
@@ -758,9 +758,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
-            "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+            "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
             "cpu": [
                 "x64"
             ],
@@ -775,9 +775,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
-            "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+            "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
             "cpu": [
                 "arm64"
             ],
@@ -792,9 +792,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
-            "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+            "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
             "cpu": [
                 "x64"
             ],
@@ -809,9 +809,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
-            "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+            "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
             "cpu": [
                 "arm64"
             ],
@@ -826,9 +826,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
-            "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+            "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
             "cpu": [
                 "x64"
             ],
@@ -843,9 +843,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
-            "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+            "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
             "cpu": [
                 "arm"
             ],
@@ -860,9 +860,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
-            "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+            "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
             "cpu": [
                 "arm64"
             ],
@@ -877,9 +877,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
-            "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+            "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
             "cpu": [
                 "ia32"
             ],
@@ -894,9 +894,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
-            "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+            "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
             "cpu": [
                 "loong64"
             ],
@@ -911,9 +911,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
-            "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+            "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
             "cpu": [
                 "mips64el"
             ],
@@ -928,9 +928,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
-            "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+            "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -945,9 +945,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
-            "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+            "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
             "cpu": [
                 "riscv64"
             ],
@@ -962,9 +962,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
-            "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+            "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
             "cpu": [
                 "s390x"
             ],
@@ -979,9 +979,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
-            "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+            "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
             "cpu": [
                 "x64"
             ],
@@ -996,9 +996,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
-            "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+            "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
             "cpu": [
                 "arm64"
             ],
@@ -1013,9 +1013,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
-            "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+            "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
             "cpu": [
                 "x64"
             ],
@@ -1030,9 +1030,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
-            "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+            "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1047,9 +1047,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
-            "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+            "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
             "cpu": [
                 "x64"
             ],
@@ -1064,9 +1064,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
-            "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+            "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
             "cpu": [
                 "arm64"
             ],
@@ -1081,9 +1081,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
-            "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+            "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
             "cpu": [
                 "x64"
             ],
@@ -1098,9 +1098,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
-            "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+            "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1115,9 +1115,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
-            "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+            "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
             "cpu": [
                 "ia32"
             ],
@@ -1132,9 +1132,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
-            "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+            "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
             "cpu": [
                 "x64"
             ],
@@ -1267,9 +1267,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-            "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^0.15.1",
@@ -2225,9 +2225,9 @@
             }
         },
         "node_modules/@pkgr/core": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-            "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+            "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2248,16 +2248,16 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-beta.19",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
-            "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
+            "version": "1.0.0-beta.27",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.2.tgz",
-            "integrity": "sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.1.tgz",
+            "integrity": "sha512-oENme6QxtLCqjChRUUo3S6X8hjCXnWmJWnedD7VbGML5GUtaOtAyx+fEEXnBXVf0CBZApMQU0Idwi0FmyxzQhw==",
             "cpu": [
                 "arm"
             ],
@@ -2269,9 +2269,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.2.tgz",
-            "integrity": "sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.1.tgz",
+            "integrity": "sha512-OikvNT3qYTl9+4qQ9Bpn6+XHM+ogtFadRLuT2EXiFQMiNkXFLQfNVppi5o28wvYdHL2s3fM0D/MZJ8UkNFZWsw==",
             "cpu": [
                 "arm64"
             ],
@@ -2283,9 +2283,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.2.tgz",
-            "integrity": "sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.1.tgz",
+            "integrity": "sha512-EFYNNGij2WllnzljQDQnlFTXzSJw87cpAs4TVBAWLdkvic5Uh5tISrIL6NRcxoh/b2EFBG/TK8hgRrGx94zD4A==",
             "cpu": [
                 "arm64"
             ],
@@ -2297,9 +2297,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.2.tgz",
-            "integrity": "sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.1.tgz",
+            "integrity": "sha512-ZaNH06O1KeTug9WI2+GRBE5Ujt9kZw4a1+OIwnBHal92I8PxSsl5KpsrPvthRynkhMck4XPdvY0z26Cym/b7oA==",
             "cpu": [
                 "x64"
             ],
@@ -2311,9 +2311,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.2.tgz",
-            "integrity": "sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.1.tgz",
+            "integrity": "sha512-n4SLVebZP8uUlJ2r04+g2U/xFeiQlw09Me5UFqny8HGbARl503LNH5CqFTb5U5jNxTouhRjai6qPT0CR5c/Iig==",
             "cpu": [
                 "arm64"
             ],
@@ -2325,9 +2325,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.2.tgz",
-            "integrity": "sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.1.tgz",
+            "integrity": "sha512-8vu9c02F16heTqpvo3yeiu7Vi1REDEC/yES/dIfq3tSXe6mLndiwvYr3AAvd1tMNUqE9yeGYa5w7PRbI5QUV+w==",
             "cpu": [
                 "x64"
             ],
@@ -2339,9 +2339,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.2.tgz",
-            "integrity": "sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.1.tgz",
+            "integrity": "sha512-K4ncpWl7sQuyp6rWiGUvb6Q18ba8mzM0rjWJ5JgYKlIXAau1db7hZnR0ldJvqKWWJDxqzSLwGUhA4jp+KqgDtQ==",
             "cpu": [
                 "arm"
             ],
@@ -2353,9 +2353,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.2.tgz",
-            "integrity": "sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.1.tgz",
+            "integrity": "sha512-YykPnXsjUjmXE6j6k2QBBGAn1YsJUix7pYaPLK3RVE0bQL2jfdbfykPxfF8AgBlqtYbfEnYHmLXNa6QETjdOjQ==",
             "cpu": [
                 "arm"
             ],
@@ -2367,9 +2367,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.2.tgz",
-            "integrity": "sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.1.tgz",
+            "integrity": "sha512-kKvqBGbZ8i9pCGW3a1FH3HNIVg49dXXTsChGFsHGXQaVJPLA4f/O+XmTxfklhccxdF5FefUn2hvkoGJH0ScWOA==",
             "cpu": [
                 "arm64"
             ],
@@ -2381,9 +2381,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.2.tgz",
-            "integrity": "sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.1.tgz",
+            "integrity": "sha512-zzX5nTw1N1plmqC9RGC9vZHFuiM7ZP7oSWQGqpbmfjK7p947D518cVK1/MQudsBdcD84t6k70WNczJOct6+hdg==",
             "cpu": [
                 "arm64"
             ],
@@ -2395,9 +2395,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.2.tgz",
-            "integrity": "sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.1.tgz",
+            "integrity": "sha512-O8CwgSBo6ewPpktFfSDgB6SJN9XDcPSvuwxfejiddbIC/hn9Tg6Ai0f0eYDf3XvB/+PIWzOQL+7+TZoB8p9Yuw==",
             "cpu": [
                 "loong64"
             ],
@@ -2408,10 +2408,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.2.tgz",
-            "integrity": "sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==",
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.1.tgz",
+            "integrity": "sha512-JnCfFVEKeq6G3h3z8e60kAp8Rd7QVnWCtPm7cxx+5OtP80g/3nmPtfdCXbVl063e3KsRnGSKDHUQMydmzc/wBA==",
             "cpu": [
                 "ppc64"
             ],
@@ -2423,9 +2423,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.2.tgz",
-            "integrity": "sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.1.tgz",
+            "integrity": "sha512-dVxuDqS237eQXkbYzQQfdf/njgeNw6LZuVyEdUaWwRpKHhsLI+y4H/NJV8xJGU19vnOJCVwaBFgr936FHOnJsQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -2437,9 +2437,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.2.tgz",
-            "integrity": "sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.1.tgz",
+            "integrity": "sha512-CvvgNl2hrZrTR9jXK1ye0Go0HQRT6ohQdDfWR47/KFKiLd5oN5T14jRdUVGF4tnsN8y9oSfMOqH6RuHh+ck8+w==",
             "cpu": [
                 "riscv64"
             ],
@@ -2451,9 +2451,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.2.tgz",
-            "integrity": "sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.1.tgz",
+            "integrity": "sha512-x7ANt2VOg2565oGHJ6rIuuAon+A8sfe1IeUx25IKqi49OjSr/K3awoNqr9gCwGEJo9OuXlOn+H2p1VJKx1psxA==",
             "cpu": [
                 "s390x"
             ],
@@ -2465,9 +2465,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz",
-            "integrity": "sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.1.tgz",
+            "integrity": "sha512-9OADZYryz/7E8/qt0vnaHQgmia2Y0wrjSSn1V/uL+zw/i7NUhxbX4cHXdEQ7dnJgzYDS81d8+tf6nbIdRFZQoQ==",
             "cpu": [
                 "x64"
             ],
@@ -2479,9 +2479,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.2.tgz",
-            "integrity": "sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.1.tgz",
+            "integrity": "sha512-NuvSCbXEKY+NGWHyivzbjSVJi68Xfq1VnIvGmsuXs6TCtveeoDRKutI5vf2ntmNnVq64Q4zInet0UDQ+yMB6tA==",
             "cpu": [
                 "x64"
             ],
@@ -2493,9 +2493,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.2.tgz",
-            "integrity": "sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.1.tgz",
+            "integrity": "sha512-mWz+6FSRb82xuUMMV1X3NGiaPFqbLN9aIueHleTZCc46cJvwTlvIh7reQLk4p97dv0nddyewBhwzryBHH7wtPw==",
             "cpu": [
                 "arm64"
             ],
@@ -2507,9 +2507,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.2.tgz",
-            "integrity": "sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.1.tgz",
+            "integrity": "sha512-7Thzy9TMXDw9AU4f4vsLNBxh7/VOKuXi73VH3d/kHGr0tZ3x/ewgL9uC7ojUKmH1/zvmZe2tLapYcZllk3SO8Q==",
             "cpu": [
                 "ia32"
             ],
@@ -2521,9 +2521,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.2.tgz",
-            "integrity": "sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.1.tgz",
+            "integrity": "sha512-7GVB4luhFmGUNXXJhH2jJwZCFB3pIOixv2E3s17GQHBFUOQaISlt7aGcQgqvCaDSxTZJUzlK/QJ1FN8S94MrzQ==",
             "cpu": [
                 "x64"
             ],
@@ -2542,9 +2542,9 @@
             "license": "MIT"
         },
         "node_modules/@testing-library/dom": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-            "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -2553,9 +2553,9 @@
                 "@babel/runtime": "^7.12.5",
                 "@types/aria-query": "^5.0.1",
                 "aria-query": "5.3.0",
-                "chalk": "^4.1.0",
                 "dom-accessibility-api": "^0.5.9",
                 "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
                 "pretty-format": "^27.0.2"
             },
             "engines": {
@@ -2563,38 +2563,24 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-            "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.4.tgz",
+            "integrity": "sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.0",
                 "aria-query": "^5.0.0",
-                "chalk": "^3.0.0",
                 "css.escape": "^1.5.1",
                 "dom-accessibility-api": "^0.6.3",
                 "lodash": "^4.17.21",
+                "picocolors": "^1.1.1",
                 "redent": "^3.0.0"
             },
             "engines": {
                 "node": ">=14",
                 "npm": ">=6",
                 "yarn": ">=1"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -2753,16 +2739,16 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.6.0.tgz",
-            "integrity": "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.27.4",
+                "@babel/core": "^7.28.0",
                 "@babel/plugin-transform-react-jsx-self": "^7.27.1",
                 "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-                "@rolldown/pluginutils": "1.0.0-beta.19",
+                "@rolldown/pluginutils": "1.0.0-beta.27",
                 "@types/babel__core": "^7.20.5",
                 "react-refresh": "^0.17.0"
             },
@@ -2770,7 +2756,7 @@
                 "node": "^14.18.0 || >=16.0.0"
             },
             "peerDependencies": {
-                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
         "node_modules/@vitest/expect": {
@@ -3863,9 +3849,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.182",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
-            "integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
+            "version": "1.5.191",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
+            "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -4082,9 +4068,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
-            "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+            "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -4095,32 +4081,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.6",
-                "@esbuild/android-arm": "0.25.6",
-                "@esbuild/android-arm64": "0.25.6",
-                "@esbuild/android-x64": "0.25.6",
-                "@esbuild/darwin-arm64": "0.25.6",
-                "@esbuild/darwin-x64": "0.25.6",
-                "@esbuild/freebsd-arm64": "0.25.6",
-                "@esbuild/freebsd-x64": "0.25.6",
-                "@esbuild/linux-arm": "0.25.6",
-                "@esbuild/linux-arm64": "0.25.6",
-                "@esbuild/linux-ia32": "0.25.6",
-                "@esbuild/linux-loong64": "0.25.6",
-                "@esbuild/linux-mips64el": "0.25.6",
-                "@esbuild/linux-ppc64": "0.25.6",
-                "@esbuild/linux-riscv64": "0.25.6",
-                "@esbuild/linux-s390x": "0.25.6",
-                "@esbuild/linux-x64": "0.25.6",
-                "@esbuild/netbsd-arm64": "0.25.6",
-                "@esbuild/netbsd-x64": "0.25.6",
-                "@esbuild/openbsd-arm64": "0.25.6",
-                "@esbuild/openbsd-x64": "0.25.6",
-                "@esbuild/openharmony-arm64": "0.25.6",
-                "@esbuild/sunos-x64": "0.25.6",
-                "@esbuild/win32-arm64": "0.25.6",
-                "@esbuild/win32-ia32": "0.25.6",
-                "@esbuild/win32-x64": "0.25.6"
+                "@esbuild/aix-ppc64": "0.25.8",
+                "@esbuild/android-arm": "0.25.8",
+                "@esbuild/android-arm64": "0.25.8",
+                "@esbuild/android-x64": "0.25.8",
+                "@esbuild/darwin-arm64": "0.25.8",
+                "@esbuild/darwin-x64": "0.25.8",
+                "@esbuild/freebsd-arm64": "0.25.8",
+                "@esbuild/freebsd-x64": "0.25.8",
+                "@esbuild/linux-arm": "0.25.8",
+                "@esbuild/linux-arm64": "0.25.8",
+                "@esbuild/linux-ia32": "0.25.8",
+                "@esbuild/linux-loong64": "0.25.8",
+                "@esbuild/linux-mips64el": "0.25.8",
+                "@esbuild/linux-ppc64": "0.25.8",
+                "@esbuild/linux-riscv64": "0.25.8",
+                "@esbuild/linux-s390x": "0.25.8",
+                "@esbuild/linux-x64": "0.25.8",
+                "@esbuild/netbsd-arm64": "0.25.8",
+                "@esbuild/netbsd-x64": "0.25.8",
+                "@esbuild/openbsd-arm64": "0.25.8",
+                "@esbuild/openbsd-x64": "0.25.8",
+                "@esbuild/openharmony-arm64": "0.25.8",
+                "@esbuild/sunos-x64": "0.25.8",
+                "@esbuild/win32-arm64": "0.25.8",
+                "@esbuild/win32-ia32": "0.25.8",
+                "@esbuild/win32-x64": "0.25.8"
             }
         },
         "node_modules/escalade": {
@@ -5905,9 +5891,9 @@
             }
         },
         "node_modules/loupe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
-            "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+            "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
             "dev": true,
             "license": "MIT"
         },
@@ -6094,9 +6080,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.20",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+            "version": "2.2.21",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+            "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
             "dev": true,
             "license": "MIT"
         },
@@ -6840,9 +6826,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
-            "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.1.tgz",
+            "integrity": "sha512-33xGNBsDJAkzt0PvninskHlWnTIPgDtTwhg0U38CUoNP/7H6wI2Cz6dUeoNPbjdTdsYTGuiFFASuUOWovH0SyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6856,26 +6842,26 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.44.2",
-                "@rollup/rollup-android-arm64": "4.44.2",
-                "@rollup/rollup-darwin-arm64": "4.44.2",
-                "@rollup/rollup-darwin-x64": "4.44.2",
-                "@rollup/rollup-freebsd-arm64": "4.44.2",
-                "@rollup/rollup-freebsd-x64": "4.44.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.44.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.44.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.44.2",
-                "@rollup/rollup-linux-arm64-musl": "4.44.2",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.44.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.44.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.44.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.44.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.44.2",
-                "@rollup/rollup-linux-x64-gnu": "4.44.2",
-                "@rollup/rollup-linux-x64-musl": "4.44.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.44.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.44.2",
-                "@rollup/rollup-win32-x64-msvc": "4.44.2",
+                "@rollup/rollup-android-arm-eabi": "4.46.1",
+                "@rollup/rollup-android-arm64": "4.46.1",
+                "@rollup/rollup-darwin-arm64": "4.46.1",
+                "@rollup/rollup-darwin-x64": "4.46.1",
+                "@rollup/rollup-freebsd-arm64": "4.46.1",
+                "@rollup/rollup-freebsd-x64": "4.46.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.46.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.46.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.46.1",
+                "@rollup/rollup-linux-arm64-musl": "4.46.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.46.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.46.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.46.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.46.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.46.1",
+                "@rollup/rollup-linux-x64-gnu": "4.46.1",
+                "@rollup/rollup-linux-x64-musl": "4.46.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.46.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.46.1",
+                "@rollup/rollup-win32-x64-msvc": "4.46.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -7450,13 +7436,13 @@
             "license": "MIT"
         },
         "node_modules/synckit": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
-            "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+            "version": "0.11.11",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+            "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@pkgr/core": "^0.2.4"
+                "@pkgr/core": "^0.2.9"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -7518,9 +7504,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7816,15 +7802,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
-            "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
+            "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.6",
-                "picomatch": "^4.0.2",
+                "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
                 "rollup": "^4.40.0",
                 "tinyglobby": "^0.2.14"
@@ -7929,9 +7915,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8015,9 +8001,9 @@
             }
         },
         "node_modules/vitest/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/src/Service.Host/vite.config.js
+++ b/src/Service.Host/vite.config.js
@@ -36,6 +36,13 @@ export default defineConfig(({ mode }) => {
             loader: { '.js': 'jsx' },
             include: /src\/.*\.js$/
         },
+        optimizeDeps: {
+            esbuildOptions: {
+                loader: {
+                    '.js': 'jsx'
+                }
+            }
+        },
         test: {
             globals: true,
             environment: 'jsdom',

--- a/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
+++ b/tests/TestData/TestData/FunctionCodes/TestFunctionCodes.cs
@@ -807,8 +807,8 @@
                     {
                         FunctionCode = "WOFF QC",
                         Seq = 1,
-                        TransactionDefinition = TestTransDefs.WriteOffQC,
-                        TransactionCode = TestTransDefs.WriteOffQC.TransactionCode,
+                        TransactionDefinition = TestTransDefs.WriteOffGoodsInInspection,
+                        TransactionCode = TestTransDefs.WriteOffGoodsInInspection.TransactionCode,
                         ReqType = "F"
                     },
                     new StoresFunctionTransaction

--- a/tests/TestData/TestData/Requisitions/LineWithPostings.cs
+++ b/tests/TestData/TestData/Requisitions/LineWithPostings.cs
@@ -1,0 +1,27 @@
+﻿namespace Linn.Stores2.TestData.Requisitions
+{
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Stores;
+
+    public class LineWithPostings : RequisitionLine
+    {
+        public LineWithPostings(
+            int reqNumber,
+            int lineNumber,
+            StoresTransactionDefinition transactionDefinition,
+            decimal? quantity = null,
+            Part part = null,
+            ICollection<RequisitionLinePosting> postings = null)
+        {
+            this.TransactionDefinition = transactionDefinition;
+            this.ReqNumber = reqNumber;
+            this.LineNumber = lineNumber;
+            this.Part = part ?? new Part();
+            this.Qty = quantity ?? 1;
+            this.Moves = new List<ReqMove>();
+            this.NominalAccountPostings = postings;
+        }
+    }
+}

--- a/tests/TestData/TestData/Transactions/TestTransDefs.cs
+++ b/tests/TestData/TestData/Transactions/TestTransDefs.cs
@@ -672,7 +672,7 @@
                 }
             };
 
-        public static readonly StoresTransactionDefinition WriteOffQC =
+        public static readonly StoresTransactionDefinition WriteOffGoodsInInspection =
             new StoresTransactionDefinition
             {
                 TransactionCode = "GIWOI",
@@ -694,5 +694,26 @@
                     new StoresTransactionState("F", "GIWOI", "FAIL")
                 }
             };
+
+        public static readonly StoresTransactionDefinition WriteOffUnusableStock =
+            new StoresTransactionDefinition
+                {
+                    TransactionCode = "STWOI",
+                    Description = "WRITE OFF DAMAGED/UNUSABLE STOCK",
+                    StockAllocations = "Y",
+                    OntoTransactions = "N",
+                    DecrementTransaction = "N",
+                    TakePriceFrom = "P",
+                    RequiresAuth = "Y",
+                    AuthOpCode = "STORESAUTH",
+                    StoresTransactionPostings = new List<StoresTransactionPosting>
+                                                    {
+                                                        new StoresTransactionPosting("STWOI", "D", new Nominal("0000004729", "STOCK WRITE OFF"))
+                                                            {
+                                                                DepartmentRule = "INPUT"
+                                                            },
+                                                        new StoresTransactionPosting("STWOI", "C", null)
+                                                    }
+                };
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/LdReqCreationStrategyTests/WhenCreatingWriteOffQC.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionCreationStrategyTests/LdReqCreationStrategyTests/WhenCreatingWriteOffQC.cs
@@ -35,7 +35,7 @@
                                     {
                                         Qty = 1,
                                         LineNumber = 1,
-                                        TransactionDefinition = TestTransDefs.WriteOffQC.TransactionCode,
+                                        TransactionDefinition = TestTransDefs.WriteOffGoodsInInspection.TransactionCode,
                                         PartNumber = "PART",
                                     }
                             },
@@ -52,8 +52,8 @@
                     AuthorisedActions.GetRequisitionActionByFunction(context.Function.FunctionCode),
                     Arg.Any<IEnumerable<string>>())
                 .Returns(true);
-            this.StoresTransactionDefinitionRepository.FindByIdAsync(TestTransDefs.WriteOffQC.TransactionCode)
-                .Returns(TestTransDefs.WriteOffQC);
+            this.StoresTransactionDefinitionRepository.FindByIdAsync(TestTransDefs.WriteOffGoodsInInspection.TransactionCode)
+                .Returns(TestTransDefs.WriteOffGoodsInInspection);
 
             this.RequisitionManager.Validate(
                 Arg.Any<int>(),

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenApplyingNominalAccountChange.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenApplyingNominalAccountChange.cs
@@ -1,6 +1,0 @@
-﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionHeaderTests
-{
-    public class WhenApplyingNominalAccountChange
-    {
-    }
-}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenApplyingNominalAccountChange.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenApplyingNominalAccountChange.cs
@@ -1,0 +1,6 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionHeaderTests
+{
+    public class WhenApplyingNominalAccountChange
+    {
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenUpdating.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenUpdating.cs
@@ -1,17 +1,13 @@
-﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionHeaderTests
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
 
     using FluentAssertions;
 
-    using Linn.Common.Domain;
     using Linn.Stores2.Domain.LinnApps.Accounts;
-    using Linn.Stores2.Domain.LinnApps.Exceptions;
     using Linn.Stores2.Domain.LinnApps.Parts;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests;
     using Linn.Stores2.TestData.FunctionCodes;
     using Linn.Stores2.TestData.Requisitions;
     using Linn.Stores2.TestData.Transactions;

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenUpdatingAndBooked.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionHeaderTests/WhenUpdatingAndBooked.cs
@@ -32,7 +32,7 @@
             req.AddLine(new LineWithMoves(1, 1, TestTransDefs.StockToLinnDept));
             req.Book(new Employee());
 
-            this.action = () => req.Update("new comment", null, null);
+            this.action = () => req.Update("new comment", null);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionLineTests/WhenApplyingNominalAccountChangeAndBooked.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionLineTests/WhenApplyingNominalAccountChangeAndBooked.cs
@@ -1,0 +1,70 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionLineTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.TestData.Requisitions;
+    using Linn.Stores2.TestData.Transactions;
+
+    using NUnit.Framework;
+
+    public class WhenApplyingNominalAccountChangeAndBooked
+    {
+        private Action action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var stockWriteOffNominal = new Nominal("4729", "STOCK WRITE OFF");
+
+            var line =  new LineWithPostings(
+                1234,
+                1,
+                TestTransDefs.WriteOffUnusableStock,
+                10m,
+                new Part(),
+                new List<RequisitionLinePosting>
+                    {
+                        new RequisitionLinePosting
+                            {
+                                ReqNumber = 1234,
+                                LineNumber = 1,
+                                Seq = 1,
+                                Qty = 10m,
+                                DebitOrCredit = "D",
+                                NominalAccount = new NominalAccount(
+                                    new Department("1401", "PURCHASING"),
+                                    stockWriteOffNominal,
+                                    "Y")
+                            },
+                        new RequisitionLinePosting
+                            {
+                                ReqNumber = 1234,
+                                LineNumber = 1,
+                                Seq = 1,
+                                Qty = 10m,
+                                DebitOrCredit = "C",
+                                NominalAccount = new NominalAccount(
+                                    new Department("2508", "ASSETS"),
+                                    new Nominal("7617", "RAW MATERIALS"),
+                                    "Y")
+                            },
+                    });
+            line.Book(DateTime.Now);
+            this.action = () => line.ApplyNominalAccountUpdate(
+                new NominalAccount(new Department("1801", "DEBUG"), stockWriteOffNominal, "Y"));
+        }
+
+        [Test]
+        public void ShouldUpdateDebitPostingDepartment()
+        {
+            this.action.Should().Throw<RequisitionException>().WithMessage("Cannot change nominal account for a booked line");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionLineTests/WhenApplyingNominalAccountChangeForWOFFQC.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionLineTests/WhenApplyingNominalAccountChangeForWOFFQC.cs
@@ -1,0 +1,69 @@
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionLineTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Parts;
+    using Linn.Stores2.Domain.LinnApps.Requisitions;
+    using Linn.Stores2.TestData.Requisitions;
+    using Linn.Stores2.TestData.Transactions;
+
+    using NUnit.Framework;
+
+    public class WhenApplyingNominalAccountChangeForWoffqc
+    {
+        private RequisitionLine sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var stockWriteOffNominal = new Nominal("4729", "STOCK WRITE OFF");
+
+            this.sut = new LineWithPostings(
+                1234,
+                1,
+                TestTransDefs.WriteOffUnusableStock,
+                10m,
+                new Part(),
+                new List<RequisitionLinePosting>
+                    {
+                        new RequisitionLinePosting
+                            {
+                                ReqNumber = 1234,
+                                LineNumber = 1,
+                                Seq = 1,
+                                Qty = 10m,
+                                DebitOrCredit = "D",
+                                NominalAccount = new NominalAccount(
+                                    new Department("1401", "PURCHASING"),
+                                    stockWriteOffNominal,
+                                    "Y")
+                            },
+                        new RequisitionLinePosting
+                            {
+                                ReqNumber = 1234,
+                                LineNumber = 1,
+                                Seq = 1,
+                                Qty = 10m,
+                                DebitOrCredit = "C",
+                                NominalAccount = new NominalAccount(
+                                    new Department("2508", "ASSETS"),
+                                    new Nominal("7617", "RAW MATERIALS"),
+                                    "Y")
+                            },
+                    });
+            this.sut.ApplyNominalAccountUpdate(
+                new NominalAccount(new Department("1801", "DEBUG"), stockWriteOffNominal, "Y"));
+        }
+
+        [Test]
+        public void ShouldUpdateDebitPostingDepartment()
+        {
+            this.sut.NominalAccountPostings.First(x => x.DebitOrCredit == "D").NominalAccount.Department.DepartmentCode
+                .Should().Be("1801");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
@@ -98,8 +98,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
                 Arg.Any<string>(),
                 Arg.Any<string>())
                 .Returns(new ProcessResult(true, "State ok"));
-            this.StoresService.ValidDepartmentNominal("0000011111", "0000022222")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000011111", "0000022222")
+                .Returns(new NominalAccount(new Department(), new Nominal(), "Y"));
             this.StateRepository.FindByIdAsync("STORES").Returns(new StockState("STORES", "LOVELY STOCK"));
 
             this.Sut = new RequisitionManager(

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/ContextBase.cs
@@ -14,7 +14,7 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
 
     using NUnit.Framework;
 
-    public class ContextBase
+    public class ContextBase 
     {
         protected IRequisitionManager Sut { get; set; }
         

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
@@ -62,8 +62,8 @@
             var updatedDept = new Department { DepartmentCode = "0002" };
             this.DepartmentRepository.FindByIdAsync(updatedDept.DepartmentCode).Returns(updatedDept);
 
-            this.StoresService.ValidDepartmentNominal(updatedDept.DepartmentCode, this.sut.Nominal.NominalCode)
-                .Returns(new ProcessResult(true, string.Empty));
+            this.StoresService.ValidNominalAccount(updatedDept.DepartmentCode, this.sut.Nominal.NominalCode)
+                .Returns(new NominalAccount());
 
             this.Sut.UpdateRequisition(
                 this.sut,
@@ -81,7 +81,7 @@
         {
             this.sut.Comments.Should().Be("NEW COMMENT");
             this.sut.Reference.Should().Be("NEW REF");
-            this.sut.Department.DepartmentCode.Should().Be("0002");
+            // this.sut.Department.DepartmentCode.Should().Be("0002");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
@@ -59,17 +59,11 @@
                 .Returns(TestTransDefs.StockToLinnDept);
             this.NominalRepository.FindByIdAsync(nom.NominalCode).Returns(nom);
 
-            var updatedDept = new Department { DepartmentCode = "0002" };
-            this.DepartmentRepository.FindByIdAsync(updatedDept.DepartmentCode).Returns(updatedDept);
-
-            this.StoresService.ValidNominalAccount(updatedDept.DepartmentCode, this.sut.Nominal.NominalCode)
-                .Returns(new NominalAccount());
-
             this.Sut.UpdateRequisition(
                 this.sut,
                 "NEW COMMENT",
                 "NEW REF",
-                updatedDept.DepartmentCode,
+                this.sut.Department.DepartmentCode,
                 new List<LineCandidate>
                 {
                 },
@@ -81,7 +75,6 @@
         {
             this.sut.Comments.Should().Be("NEW COMMENT");
             this.sut.Reference.Should().Be("NEW REF");
-            // this.sut.Department.DepartmentCode.Should().Be("0002");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdating.cs
@@ -1,4 +1,4 @@
-﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionHeaderTests
+﻿namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
 {
     using System.Collections.Generic;
 
@@ -7,7 +7,6 @@
     using Linn.Stores2.Domain.LinnApps.Accounts;
     using Linn.Stores2.Domain.LinnApps.Parts;
     using Linn.Stores2.Domain.LinnApps.Requisitions;
-    using Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests;
     using Linn.Stores2.TestData.FunctionCodes;
     using Linn.Stores2.TestData.Requisitions;
     using Linn.Stores2.TestData.Transactions;
@@ -18,14 +17,14 @@
 
     public class WhenUpdating : ContextBase
     {
-        private RequisitionHeader sut;
+        private RequisitionHeader req;
 
         [SetUp]
         public void Setup()
         {
             var dept = new Department { DepartmentCode = "0001" };
             var nom = new Nominal { NominalCode = "0002" };
-            this.sut = new ReqWithReqNumber(
+            this.req = new ReqWithReqNumber(
                 123,
                 new Employee(),
                 TestFunctionCodes.LinnDeptReq,
@@ -43,7 +42,7 @@
                 new Part(),
                 10,
                 TestTransDefs.StockToLinnDept);
-            this.sut.AddLine(requisitionLine);
+            this.req.AddLine(requisitionLine);
             this.AuthService.HasPermissionFor(
                 AuthorisedActions.GetRequisitionActionByFunction(
                     TestFunctionCodes.LinnDeptReq.FunctionCode),
@@ -56,10 +55,10 @@
             this.NominalRepository.FindByIdAsync(nom.NominalCode).Returns(nom);
 
             this.Sut.UpdateRequisition(
-                this.sut,
+                this.req,
                 "NEW COMMENT",
                 "NEW REF",
-                this.sut.Department.DepartmentCode,
+                this.req.Department.DepartmentCode,
                 new List<LineCandidate>
                 {
                 },
@@ -69,8 +68,8 @@
         [Test]
         public void ShouldUpdate()
         {
-            this.sut.Comments.Should().Be("NEW COMMENT");
-            this.sut.Reference.Should().Be("NEW REF");
+            this.req.Comments.Should().Be("NEW COMMENT");
+            this.req.Reference.Should().Be("NEW REF");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdatingAndInvalidDepartmentForNominal.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenUpdatingAndInvalidDepartmentForNominal.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
 
     using FluentAssertions;
@@ -17,6 +16,7 @@
     using Linn.Stores2.TestData.Transactions;
 
     using NSubstitute;
+    using NSubstitute.ExceptionExtensions;
 
     using NUnit.Framework;
 
@@ -62,8 +62,8 @@
             var updatedDept = new Department { DepartmentCode = "0002" };
             this.DepartmentRepository.FindByIdAsync(updatedDept.DepartmentCode).Returns(updatedDept);
 
-            this.StoresService.ValidDepartmentNominal(updatedDept.DepartmentCode, req.Nominal.NominalCode)
-                .Returns(new ProcessResult(false, string.Empty));
+            this.StoresService.ValidNominalAccount(updatedDept.DepartmentCode, req.Nominal.NominalCode)
+                .Throws(new InvalidNominalAccountException("Dept Nom Not Ok"));
 
             this.action = async () => await this.Sut.UpdateRequisition(
                 req,
@@ -79,7 +79,7 @@
         [Test]
         public async Task ShouldThrow()
         {
-            await this.action.Should().ThrowAsync<RequisitionException>();
+            await this.action.Should().ThrowAsync<InvalidNominalAccountException>();
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAdjust.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAdjust.cs
@@ -33,8 +33,8 @@
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("0000042808", "0000004710")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000042808", "0000004710")
+                .Returns(new NominalAccount());
             this.result = await this.Sut.Validate(
                 33087,
                 TestFunctionCodes.Adjust.FunctionCode,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesInvalidPalletNumber.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesInvalidPalletNumber.cs
@@ -36,8 +36,8 @@
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StoresMove.TransactionCode)
                 .Returns(TestTransDefs.StoresMove);
             this.PalletRepository.FindByIdAsync(666).Returns(new StoresPallet { DateInvalid = DateTime.Today });
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok")); 
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount()); 
             
             this.act = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToPallet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToPallet.cs
@@ -34,8 +34,8 @@
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StoresMove.TransactionCode)
                 .Returns(TestTransDefs.StoresMove);
-            this.StoresService.ValidDepartmentNominal("0000001607", "0000002963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000001607", "0000002963")
+                .Returns(new NominalAccount());
 
             this.act = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToState.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToState.cs
@@ -36,8 +36,8 @@
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StoresMove.TransactionCode)
                 .Returns(TestTransDefs.StoresMove);
             this.PalletRepository.FindByIdAsync(666).Returns(new StoresPallet());
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.act = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToStockPool.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndHeaderSpecifiesNonExistentToStockPool.cs
@@ -37,8 +37,8 @@
                 .Returns(TestTransDefs.StoresMove);
             this.PalletRepository.FindByIdAsync(666).Returns(new StoresPallet());
             this.StateRepository.FindByIdAsync("BLAH").Returns(new StockState());
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.act = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveHasNoQty.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveHasNoQty.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StockToLinnDept.TransactionCode)
                 .Returns(TestTransDefs.StockToLinnDept);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingLocation.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingLocation.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.LinnDeptToStock);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingOnToLocation.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveMissingOnToLocation.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.LinnDeptToStock);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveOntoSpecifiesInvalidPallet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveOntoSpecifiesInvalidPallet.cs
@@ -38,8 +38,8 @@
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.StockToLinnDept);
             this.PalletRepository.FindByIdAsync(666).Returns(new StoresPallet { DateInvalid = DateTime.Now });
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveOntoSpecifiesNonExistingPallet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMoveOntoSpecifiesNonExistingPallet.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.StockToLinnDept);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMovesFromSpecifyBothLocationCodeAndPallet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndMovesFromSpecifyBothLocationCodeAndPallet.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync(part.PartNumber).Returns(part);
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.LinnDeptToStock);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndNoLinesWhenRequiredByStoresFunction.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndNoLinesWhenRequiredByStoresFunction.cs
@@ -36,8 +36,8 @@
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.StockToLinnDept.TransactionCode)
                 .Returns(TestTransDefs.StockToLinnDept);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndNoMovesOntoWhenSpecifiedByLineTransaction.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndNoMovesOntoWhenSpecifiedByLineTransaction.cs
@@ -38,8 +38,8 @@
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.TransactionDefinitionRepository.FindByIdAsync(TestTransDefs.LinnDeptToStock.TransactionCode)
                 .Returns(TestTransDefs.LinnDeptToStock);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndSecondLineHasNoQty.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAndSecondLineHasNoQty.cs
@@ -74,8 +74,8 @@
                     Moves = new[] { new MoveSpecification { Qty = 0 } }
                 }
             };
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAudit.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAudit.cs
@@ -45,8 +45,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
                 .Returns(new ProcessResult(true, "ok"));
             this.AuditLocationRepository.FindByAsync(Arg.Any<Expression<Func<AuditLocation, bool>>>())
                 .Returns(new AuditLocation());
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.result = await this.Sut.Validate(
                 100,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAuditAndAuditLocationDoesNotExist.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAuditAndAuditLocationDoesNotExist.cs
@@ -43,8 +43,8 @@
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 456).Returns(true);
             this.StockService.ValidStockLocation(null, 123, "PART", 1, null, "LINN")
                 .Returns(new ProcessResult(true, "ok"));
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 100,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAuditNotEnoughStock.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingAuditNotEnoughStock.cs
@@ -46,8 +46,8 @@
                 .Returns(new ProcessResult(false, "only got a wee bit left"));
             this.AuditLocationRepository.FindByAsync(Arg.Any<Expression<Func<AuditLocation, bool>>>())
                 .Returns(new AuditLocation());
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 100,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingBookLdAndNoNominalAccount.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingBookLdAndNoNominalAccount.cs
@@ -13,6 +13,8 @@
     using Linn.Stores2.TestData.FunctionCodes;
 
     using NSubstitute;
+    using NSubstitute.ExceptionExtensions;
+
     using NUnit.Framework;
 
     public class WhenValidatingBookLdAndNoNominalAccount : ContextBase
@@ -42,8 +44,10 @@
                                                       PartNumber = "SUNDRY PART"
                                                   }
                                           };
-            this.StoresService.ValidDepartmentNominal("0000011111", "0000022222")
-                .Returns(new ProcessResult(false, "Dept/Nom not valid"));
+
+            this.StoresService.ValidNominalAccount("0000011111", "0000022222")
+                .Throws(new InvalidNominalAccountException("Dept/Nom not valid"));
+
             this.DocumentProxy.GetPurchaseOrder(1234).Returns(
                 new PurchaseOrderResult
                 {
@@ -76,7 +80,7 @@
         [Test]
         public async Task ShouldThrowCorrectException()
         {
-            await this.action.Should().ThrowAsync<RequisitionException>()
+            await this.action.Should().ThrowAsync<InvalidNominalAccountException>()
                 .WithMessage("Dept/Nom not valid");
         }
     }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqButInvalidDeptNominal.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqButInvalidDeptNominal.cs
@@ -16,6 +16,7 @@
     using Linn.Stores2.TestData.Transactions;
 
     using NSubstitute;
+    using NSubstitute.ExceptionExtensions;
 
     using NUnit.Framework;
 
@@ -38,8 +39,8 @@
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(false, "Dept Nom Not Ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Throws(new InvalidNominalAccountException("Dept Nom Not Ok"));
 
             this.action = () => this.Sut.Validate(
                                     33087,
@@ -71,7 +72,7 @@
         [Test]
         public async Task ShouldThrowCorrectException()
         {
-            await this.action.Should().ThrowAsync<RequisitionException>()
+            await this.action.Should().ThrowAsync<InvalidNominalAccountException>()
                 .WithMessage("Dept Nom Not Ok");
         }
     }

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStock.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStock.cs
@@ -36,8 +36,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.result = await this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStockAndHeaderSpecifiesToLocation.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStockAndHeaderSpecifiesToLocation.cs
@@ -36,8 +36,8 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.RequisitionManagerTests
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.result = await this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStockWithLocButNoStockPool.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdReqOntoStockWithLocButNoStockPool.cs
@@ -38,8 +38,8 @@
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdreqFromStock.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingLdreqFromStock.cs
@@ -38,8 +38,8 @@
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
             this.StockService.ValidStockLocation(null, 123, "PART", 1, null)
                 .Returns(new ProcessResult(true, "Ok"));
-            this.StoresService.ValidDepartmentNominal("1607", "2963")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("1607", "2963")
+                .Returns(new NominalAccount());
 
             this.result = await this.Sut.Validate(
                               33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingPartNumberChange.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingPartNumberChange.cs
@@ -43,8 +43,8 @@
                 Arg.Any<StockState>()).Returns(new ProcessResult(true, null));
             this.StoresService.ValidPartNumberChange(Arg.Any<Part>(), Arg.Any<Part>())
                 .Returns(new ProcessResult(true, null));
-            this.StoresService.ValidDepartmentNominal("0000042808", "0000000480")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000042808", "0000000480")
+                .Returns(new NominalAccount());
 
             this.result = await this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingPartNumberChangeAndInvalidPartNumberChange.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingPartNumberChangeAndInvalidPartNumberChange.cs
@@ -41,8 +41,8 @@
                 Arg.Any<StockState>()).Returns(new ProcessResult(true, null));
             this.StoresService.ValidPartNumberChange(Arg.Any<Part>(), Arg.Any<Part>())
                 .Returns(new ProcessResult(false, "Invalid part number change"));
-            this.StoresService.ValidDepartmentNominal("0000042808", "0000000480")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000042808", "0000000480")
+                .Returns(new NominalAccount());
 
             this.action = () => this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingWOff.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/RequisitionManagerTests/WhenValidatingWOff.cs
@@ -32,8 +32,8 @@
             this.PalletRepository.FindByIdAsync(123).Returns(new StoresPallet());
             this.PartRepository.FindByIdAsync("PART").Returns(new Part());
             this.ReqStoredProcedures.CanPutPartOnPallet("PART", 123).Returns(true);
-            this.StoresService.ValidDepartmentNominal("0000042808", "0000004729")
-                .Returns(new ProcessResult(true, "ok"));
+            this.StoresService.ValidNominalAccount("0000042808", "0000004729")
+                .Returns(new NominalAccount(new Department(), new Nominal(), "Y"));
 
             this.result = await this.Sut.Validate(
                 33087,

--- a/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenNominalDepartmentDoesNotExist.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenNominalDepartmentDoesNotExist.cs
@@ -7,6 +7,7 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.StoresServiceTests.ValidDepartmentN
     using FluentAssertions;
 
     using Linn.Stores2.Domain.LinnApps.Accounts;
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
 
     using NSubstitute;
 
@@ -14,21 +15,22 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.StoresServiceTests.ValidDepartmentN
 
     public class WhenNominalDepartmentDoesNotExist : ContextBase
     {
+        private Func<Task> action;
+
         [SetUp]
-        public async Task Setup()
+        public void Setup()
         {
             this.NominalAccountRepository.FindByAsync(Arg.Any<Expression<Func<NominalAccount, bool>>>())
                 .Returns((NominalAccount)null);
 
-            this.Result = await this.Sut.ValidDepartmentNominal(this.DepartmentCode, this.NominalCode);
+            this.action = () => this.Sut.ValidNominalAccount(this.DepartmentCode, this.NominalCode);
         }
 
         [Test]
-        public void ShouldReturnFailureWithCorrectMessage()
+        public async Task ShouldReturnFailureWithCorrectMessage()
         {
-            this.Result.Success.Should().BeFalse();
-            this.Result.Message.Should()
-                .Be($"Department / Nominal {this.DepartmentCode} / {this.NominalCode} are not a valid combination");
+            await this.action.Should().ThrowAsync<InvalidNominalAccountException>()
+                .WithMessage($"Department / Nominal {this.DepartmentCode} / {this.NominalCode} are not a valid combination");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenNominalDepartmentNotValidForStores.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenNominalDepartmentNotValidForStores.cs
@@ -1,27 +1,31 @@
 namespace Linn.Stores2.Domain.LinnApps.Tests.StoresServiceTests.ValidDepartmentNominalTests
 {
+    using System;
     using System.Threading.Tasks;
 
     using FluentAssertions;
+
+    using Linn.Stores2.Domain.LinnApps.Exceptions;
 
     using NUnit.Framework;
 
     public class WhenNominalDepartmentNotValidForStores : ContextBase
     {
+        private Func<Task> action;
+
         [SetUp]
-        public async Task Setup()
+        public void Setup()
         {
             this.NominalAccount.StoresPostsAllowed = "N";
 
-            this.Result = await this.Sut.ValidDepartmentNominal(this.DepartmentCode, this.NominalCode);
+            this.action = () => this.Sut.ValidNominalAccount(this.DepartmentCode, this.NominalCode);
         }
 
         [Test]
-        public void ShouldReturnFailureWithCorrectMessage()
+        public async Task ShouldThrow()
         {
-            this.Result.Success.Should().BeFalse();
-            this.Result.Message.Should()
-                .Be($"Department / Nominal {this.DepartmentCode} / {this.NominalCode} are not a valid for stores posting");
+            await this.action.Should().ThrowAsync<InvalidNominalAccountException>()
+                .WithMessage($"Department / Nominal {this.DepartmentCode} / {this.NominalCode} are not a valid for stores posting");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenValidCombination.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/StoresServiceTests/ValidDepartmentNominalTests/WhenValidCombination.cs
@@ -4,22 +4,24 @@ namespace Linn.Stores2.Domain.LinnApps.Tests.StoresServiceTests.ValidDepartmentN
 
     using FluentAssertions;
 
+    using Linn.Stores2.Domain.LinnApps.Accounts;
+
     using NUnit.Framework;
 
     public class WhenValidCombination : ContextBase
     {
+        private NominalAccount nominalAccount;
+
         [SetUp]
         public async Task Setup()
         {
-            this.Result = await this.Sut.ValidDepartmentNominal(this.DepartmentCode, this.NominalCode);
+            this.nominalAccount = await this.Sut.ValidNominalAccount(this.DepartmentCode, this.NominalCode);
         }
 
         [Test]
         public void ShouldReturnSuccess()
         {
-            this.Result.Success.Should().BeTrue();
-            this.Result.Message.Should()
-                .Be($"Department / Nominal {this.DepartmentCode} / {this.NominalCode} are a valid combination for stores");
+            this.nominalAccount.Should().NotBe(null);
         }
     }
 }


### PR DESCRIPTION
- User request is to be able to change the department on the (WOFF WC) req header after a req is created but before it is booked

- This was a bit more complicated than I first thought, since we need to consult a bunch of rules to work out how to update nominal postings for each line (i.e. whether to update the debit or credit side of the postings depending on the transaction definition of the line in question and its 'StoresTransactionPosting' rules)

- As this code stands it only permits updating the department of WOFF and WOFF QC reqs. There's not really a good reason for this other than just testing the waters - in theory the old form would support updating both nominal and departments for reqs of various function codes, but I thought I'd try deploy this simplification just to get mark moving and hopefully limit potential stock fallout if I got something wrong

- To that end, I've only really tested the happy path we care about. Most of the less-than-happy paths, exceptions and such like, are just artificial limitations I've imposed anyway (except from the case where the line is booked, which I have tested since this is a real thing)

- I wasn't too sure about this so let me know if you spot any obvious issues or omissions